### PR TITLE
Add JWT based basic authenticator.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth.jwt/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth.jwt/pom.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>identity-application-auth-basicauth</artifactId>
+        <groupId>org.wso2.carbon.identity.application.auth.basic</groupId>
+        <version>5.4.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wso2.carbon.identity.application.authenticator.basicauth.jwt</groupId>
+    <artifactId>org.wso2.carbon.identity.application.authenticator.basicauth.jwt</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Basic authentication based JWT Application Authenticator</name>
+    <dependencies>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang.wso2</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.json-simple.wso2</groupId>
+            <artifactId>json-simple</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core.services</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.application.auth.basic</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authenticator.basicauth</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package>
+                            org.wso2.carbon.identity.application.authenticator.basicauth.jwt.internal
+                        </Private-Package>
+                        <Import-Package>
+                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
+                            org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
+
+                            javax.servlet.http;version="${imp.pkg.version.javax.servlet}",
+
+                            com.nimbusds.jose.*; version="${nimbusds.imp.pkg.version.range}",
+                            com.nimbusds.jwt; version="${nimbusds.imp.pkg.version.range}",
+
+                            org.apache.commons.lang;version="${commons-lang.wso2.osgi.version.range}",
+                            org.apache.commons.logging; version="${commons-logging.osgi.version.range}",
+
+                            org.wso2.carbon.base; version="${carbon.base.imp.pkg.version.range}",
+                            org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
+                            org.wso2.carbon.user.core.service; version="${carbon.kernel.imp.pkg.version.range}",
+                            org.wso2.carbon.user.core.tenant; version="${carbon.kernel.imp.pkg.version.range}",
+                            org.wso2.carbon.utils; version="${carbon.kernel.imp.pkg.version.range}",
+                            org.wso2.carbon.core.util; version="${carbon.kernel.imp.pkg.version.range}",
+
+                            org.wso2.carbon.identity.application.authentication.framework.*;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.common.cache;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.common.model;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.core.util;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.authenticator.basicauth;
+                            version="${identity.application.auth.basicauth.imp.pkg.version.range}"
+                        </Import-Package>
+                        <Export-Package>
+                            !org.wso2.carbon.identity.application.authenticator.basicauth.jwt.internal,
+                            org.wso2.carbon.identity.application.authenticator.basicauth.jwt.*;version="${project.version}"
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth.jwt/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/jwt/JWTBasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth.jwt/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/jwt/JWTBasicAuthenticator.java
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authenticator.basicauth.jwt;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.base.MultitenantConstants;
+import org.wso2.carbon.core.util.KeyStoreManager;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.AuthenticationFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticator;
+import org.wso2.carbon.identity.application.authenticator.basicauth.jwt.cache.AuthJwtCache;
+import org.wso2.carbon.identity.application.authenticator.basicauth.jwt.internal
+        .JWTBasicAuthenticatorServiceComponentDataHolder;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Signed JWT token based Authenticator
+ */
+public class JWTBasicAuthenticator extends BasicAuthenticator {
+
+    private static final Log log = LogFactory.getLog(JWTBasicAuthenticator.class);
+
+    private static long DEFAULT_TIMESTAMP_SKEW = 300;
+
+    @Override
+    public boolean canHandle(HttpServletRequest request) {
+
+        String token = request.getParameter(JWTBasicAuthenticatorConstants.PARAM_TOKEN);
+        return token != null;
+    }
+
+    @Override
+    protected void processAuthenticationResponse(HttpServletRequest request, HttpServletResponse response,
+                                                 AuthenticationContext context) throws AuthenticationFailedException {
+
+        String authToken = request.getParameter(JWTBasicAuthenticatorConstants.PARAM_TOKEN);
+        if (log.isDebugEnabled() && IdentityUtil.isTokenLoggable(JWTBasicAuthenticatorConstants.AUTH_TOKEN)) {
+            log.debug("User authentication token : " + authToken);
+        }
+
+        Map<String, Object> authProperties = context.getProperties();
+        if (authProperties == null) {
+            authProperties = new HashMap<>();
+            context.setProperties(authProperties);
+        }
+
+        SignedJWT signedJWT = getSignedJWT(authToken);
+        JWTClaimsSet claimsSet = getClaimSet(signedJWT);
+
+        if (isValidClaimSet(claimsSet)) {
+            String username = claimsSet.getSubject();
+            User user = User.getUserFromUserName(username);
+            if (isValidSignature(signedJWT, user.getTenantDomain())) {
+                AuthJwtCache.getInstance().addToCache(claimsSet.getJWTID(), claimsSet.getJWTID());
+                authProperties.put("user-tenant-domain", user.getTenantDomain());
+                context.setSubject(AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier(username));
+                String rememberMe = request.getParameter("chkRemember");
+                if (rememberMe != null && "on".equals(rememberMe)) {
+                    context.setRememberMe(true);
+                }
+            } else {
+                throw new AuthenticationFailedException("User authentication failed : Invalid signature.");
+            }
+        } else {
+            throw new AuthenticationFailedException("Invalid token");
+        }
+    }
+
+    @Override
+    public String getFriendlyName() {
+        return JWTBasicAuthenticatorConstants.AUTHENTICATOR_FRIENDLY_NAME;
+    }
+
+    @Override
+    public String getName() {
+        return JWTBasicAuthenticatorConstants.AUTHENTICATOR_NAME;
+    }
+
+    private SignedJWT getSignedJWT(String jwtAssertion) throws AuthenticationFailedException {
+
+        String errorMessage = "No Valid JWT Assertion was found.";
+        SignedJWT signedJWT;
+        if (StringUtils.isBlank(jwtAssertion)) {
+            throw new AuthenticationFailedException(errorMessage);
+        }
+
+        try {
+            signedJWT = SignedJWT.parse(jwtAssertion);
+        } catch (ParseException e) {
+            if (log.isDebugEnabled()) {
+                log.debug(e.getMessage());
+            }
+            throw new AuthenticationFailedException("Error while parsing the JWT.");
+        }
+
+        if (signedJWT == null) {
+            throw new AuthenticationFailedException(errorMessage);
+        }
+        return signedJWT;
+    }
+
+    private JWTClaimsSet getClaimSet(SignedJWT signedJWT) throws AuthenticationFailedException {
+
+        if (signedJWT == null) {
+            throw new AuthenticationFailedException("No Valid JWT Assertion was found.");
+        }
+
+        JWTClaimsSet claimsSet;
+        try {
+            claimsSet = signedJWT.getJWTClaimsSet();
+
+            if (claimsSet == null) {
+                throw new AuthenticationFailedException("Claim values are empty in the given JWT.");
+            }
+        } catch (ParseException e) {
+            String errorMsg = "Error when trying to retrieve claimsSet from the JWT.";
+            if (log.isDebugEnabled()) {
+                log.debug(errorMsg);
+            }
+            throw new AuthenticationFailedException(errorMsg);
+        }
+        return claimsSet;
+    }
+
+    private boolean isValidClaimSet(JWTClaimsSet claimsSet) throws AuthenticationFailedException {
+
+        if (StringUtils.isEmpty(claimsSet.getSubject()) || StringUtils.isEmpty(claimsSet.getIssuer()) || StringUtils
+                .isEmpty(claimsSet.getJWTID()) || claimsSet.getExpirationTime() == null) {
+            throw new AuthenticationFailedException("Invalid token : Required fields are not present in JWT.");
+        }
+
+        if (AuthJwtCache.getInstance().getValueFromCache(claimsSet.getJWTID()) != null) {
+            throw new AuthenticationFailedException("Invalid token : Possible replay attack.");
+        }
+
+        return checkExpirationTime(claimsSet.getExpirationTime().getTime(), System.currentTimeMillis(),
+                getTimeStampSkew());
+    }
+
+    private boolean isValidSignature(SignedJWT signedJWT, String tenantDomain) throws AuthenticationFailedException {
+
+        X509Certificate cert = getCertificate(tenantDomain);
+        return validateSignature(signedJWT, cert);
+    }
+
+    private X509Certificate getCertificate(String tenantDomain) throws AuthenticationFailedException {
+
+        int tenantId;
+        try {
+            tenantId = JWTBasicAuthenticatorServiceComponentDataHolder.getInstance().getRealmService()
+                    .getTenantManager().getTenantId(tenantDomain);
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            String errorMsg = "Error while getting the tenant ID from the tenant domain : " + tenantDomain;
+            throw new AuthenticationFailedException(errorMsg);
+        }
+
+        // get an instance of the corresponding Key Store Manager instance
+        KeyStoreManager keyStoreManager = KeyStoreManager.getInstance(tenantId);
+        try {
+            if (tenantId != MultitenantConstants.SUPER_TENANT_ID) {
+                // for tenants, load key from their generated key store and get the primary certificate.
+                KeyStore keyStore = keyStoreManager.getKeyStore(generateKSNameFromDomainName(tenantDomain));
+                return (X509Certificate) keyStore.getCertificate(tenantDomain);
+            } else {
+                // for super tenant, load the default public cert using the config in carbon.xml
+                return keyStoreManager.getDefaultPrimaryCertificate();
+            }
+        } catch (KeyStoreException e) {
+            String errorMsg = "Error instantiating an X509Certificate object for the primary certificate  in tenant: " +
+                    "" + tenantDomain;
+            if (log.isDebugEnabled()) {
+                log.debug(errorMsg, e);
+            }
+            throw new AuthenticationFailedException(errorMsg);
+        } catch (Exception e) {
+            String errorMsg = "Unable to load key store manager for the tenant domain: " + tenantDomain;
+            if (log.isDebugEnabled()) {
+                log.debug(errorMsg, e);
+            }
+            throw new AuthenticationFailedException(errorMsg);
+        }
+    }
+
+    private String generateKSNameFromDomainName(String tenantDomain) {
+
+        String ksName = tenantDomain.trim().replace(JWTBasicAuthenticatorConstants.FULLSTOP_DELIMITER,
+                JWTBasicAuthenticatorConstants.DASH_DELIMITER);
+        return ksName + JWTBasicAuthenticatorConstants.KEYSTORE_FILE_EXTENSION;
+    }
+
+    private boolean validateSignature(SignedJWT signedJWT, X509Certificate x509Certificate) throws
+            AuthenticationFailedException {
+
+        JWSHeader header = signedJWT.getHeader();
+        if (x509Certificate == null) {
+            throw new AuthenticationFailedException("Unable to locate certificate for JWT " + header.toString());
+        }
+
+        JWSVerifier verifier;
+        String alg = header.getAlgorithm().getName();
+        if (StringUtils.isEmpty(alg)) {
+            throw new AuthenticationFailedException("Signature validation failed. No algorithm is found in JWT " +
+                    "header.");
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Signature Algorithm: " + alg + " found in JWT Header.");
+            }
+            // Only RSA Public Key is accepted.
+            if (alg.indexOf("RS") == 0) {
+                PublicKey publicKey = x509Certificate.getPublicKey();
+                if (publicKey instanceof RSAPublicKey) {
+                    verifier = new RSASSAVerifier((RSAPublicKey) publicKey);
+                } else {
+                    throw new AuthenticationFailedException("Signature validation failed. Public key is not an RSA "
+                            + "public key.");
+                }
+            } else {
+                throw new AuthenticationFailedException("Signature Algorithm not supported : " + alg);
+            }
+        }
+
+        try {
+            return signedJWT.verify(verifier);
+        } catch (JOSEException e) {
+            String errorMsg = "Signature verification failed for the JWT.";
+            if (log.isDebugEnabled()) {
+                log.debug(errorMsg, e);
+            }
+            throw new AuthenticationFailedException(errorMsg);
+        }
+    }
+
+    private long getTimeStampSkew() {
+
+        if (getAuthenticatorConfig().getParameterMap() != null) {
+            String timeStampSkewValue = getAuthenticatorConfig().getParameterMap().get(JWTBasicAuthenticatorConstants
+                    .TIMESTAMP_SKEW);
+            if (StringUtils.isNotBlank(timeStampSkewValue)) {
+                try {
+                    return Long.parseLong(timeStampSkewValue);
+                } catch (NumberFormatException e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Failed to parse configured 'TimestampSkew' value: " + timeStampSkewValue + " to a " +
+                                "" +  "long value. Picking the default value: " + DEFAULT_TIMESTAMP_SKEW);
+                    }
+                }
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("'TimestampSkew' is not configured in application-authentication.xml file for the " +
+                            "authenticator. Picking the default value: " + DEFAULT_TIMESTAMP_SKEW);
+                }
+            }
+        }
+
+        return DEFAULT_TIMESTAMP_SKEW;
+    }
+
+    private boolean checkExpirationTime(long expirationTimeInMillis, long currentTimeInMillis, long
+            timeStampSkewMillis) throws AuthenticationFailedException {
+
+        if ((currentTimeInMillis + timeStampSkewMillis) > expirationTimeInMillis) {
+            if (log.isDebugEnabled()) {
+                log.debug("JSON Web Token is expired." + ", Expiration Time(ms) : " + expirationTimeInMillis + ", " +
+                        "TimeStamp Skew(ms) : " + timeStampSkewMillis + ", Current Time(ms) : " + currentTimeInMillis
+                        + ". JWT Rejected and validation terminated");
+            }
+
+            throw new AuthenticationFailedException("Invalid token : Token is expired.");
+        }
+        return true;
+    }
+
+}
+
+

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth.jwt/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/jwt/JWTBasicAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth.jwt/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/jwt/JWTBasicAuthenticatorConstants.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authenticator.basicauth.jwt;
+
+public class JWTBasicAuthenticatorConstants {
+
+    public static final String FULLSTOP_DELIMITER = ".";
+    public static final String DASH_DELIMITER = "-";
+    public static final String KEYSTORE_FILE_EXTENSION = ".jks";
+
+    // Authenticator Name
+    public static final String AUTHENTICATOR_NAME = "JWTBasicAuthenticator";
+    public static final String AUTHENTICATOR_FRIENDLY_NAME = "jwt-basic";
+
+    public static final String PARAM_TOKEN = "token";
+    public static final String AUTH_TOKEN = "AuthToken";
+
+    public static final String TIMESTAMP_SKEW = "TimestampSkew";
+
+    private JWTBasicAuthenticatorConstants() {
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth.jwt/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/jwt/cache/AuthJwtCache.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth.jwt/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/jwt/cache/AuthJwtCache.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authenticator.basicauth.jwt.cache;
+
+import org.wso2.carbon.identity.application.common.cache.BaseCache;
+import org.wso2.carbon.utils.CarbonUtils;
+
+/**
+ * Implements a cache to store JWT references
+ */
+public class AuthJwtCache extends BaseCache<String,String> {
+    public static final String AUTH_JWT_CACHE = "AuthJWT";
+    private static volatile AuthJwtCache instance;
+
+    private AuthJwtCache() {
+        super(AUTH_JWT_CACHE);
+    }
+
+    public static AuthJwtCache getInstance() {
+        CarbonUtils.checkSecurity();
+        if (instance == null) {
+            synchronized (AuthJwtCache.class) {
+                if (instance == null) {
+                    instance = new AuthJwtCache();
+                }
+            }
+        }
+        return instance;
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth.jwt/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/jwt/internal/JWTBasicAuthenticatorServiceComponent.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth.jwt/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/jwt/internal/JWTBasicAuthenticatorServiceComponent.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authenticator.basicauth.jwt.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.ComponentContext;
+import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
+import org.wso2.carbon.identity.application.authenticator.basicauth.jwt.JWTBasicAuthenticator;
+import org.wso2.carbon.user.core.service.RealmService;
+
+
+/**
+ * @scr.component name="identity.application.authenticator.basicauth.jwt.component" immediate="true"
+ * @scr.reference name="realm.service"
+ * interface="org.wso2.carbon.user.core.service.RealmService"cardinality="1..1"
+ * policy="dynamic" bind="setRealmService" unbind="unsetRealmService"
+ */
+public class JWTBasicAuthenticatorServiceComponent {
+
+    private static Log log = LogFactory.getLog(JWTBasicAuthenticatorServiceComponent.class);
+
+    protected void activate(ComponentContext ctxt) {
+
+        try {
+            JWTBasicAuthenticator jwtBasicAuth = new JWTBasicAuthenticator();
+            ctxt.getBundleContext().registerService(ApplicationAuthenticator.class.getName(), jwtBasicAuth, null);
+            if (log.isDebugEnabled()) {
+                log.info("JWTBasicAuthenticator bundle is activated");
+            }
+        } catch (Throwable e) {
+            log.error("JWTBasicAuthenticator bundle activation Failed", e);
+        }
+    }
+
+    protected void deactivate(ComponentContext ctxt) {
+
+        if (log.isDebugEnabled()) {
+            log.info("JWTBasicAuthenticator bundle is deactivated");
+        }
+    }
+
+    protected void setRealmService(RealmService realmService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting the Realm Service in JWTBasicAuthenticator");
+        }
+        JWTBasicAuthenticatorServiceComponentDataHolder.getInstance().setRealmService(realmService);
+    }
+
+    protected void unsetRealmService(RealmService realmService) {
+
+        log.debug("UnSetting the Realm Service in JWTBasicAuthenticator");
+        JWTBasicAuthenticatorServiceComponentDataHolder.getInstance().setRealmService(null);
+    }
+}
+

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth.jwt/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/jwt/internal/JWTBasicAuthenticatorServiceComponentDataHolder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth.jwt/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/jwt/internal/JWTBasicAuthenticatorServiceComponentDataHolder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authenticator.basicauth.jwt.internal;
+
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * Data holder that keep references for registered listened OSGi services.
+ */
+public class JWTBasicAuthenticatorServiceComponentDataHolder {
+
+    private static JWTBasicAuthenticatorServiceComponentDataHolder instance = new JWTBasicAuthenticatorServiceComponentDataHolder();
+
+    private RealmService realmService;
+
+    public static JWTBasicAuthenticatorServiceComponentDataHolder getInstance() {
+
+        return instance;
+    }
+
+    public RealmService getRealmService() {
+
+        return realmService;
+    }
+
+    public void setRealmService(RealmService realmService) {
+
+        this.realmService = realmService;
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/pom.xml
@@ -20,7 +20,7 @@
         <groupId>org.wso2.carbon.identity.application.auth.basic</groupId>
         <artifactId>identity-application-auth-basicauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.3.8-SNAPSHOT</version>
+        <version>5.4.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.carbon.identity.application.authenticator.basicauth.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.application.authenticator.basicauth.server.feature/pom.xml
@@ -22,7 +22,7 @@
         <groupId>org.wso2.carbon.identity.application.auth.basic</groupId>
         <artifactId>identity-application-auth-basicauth</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>5.3.8-SNAPSHOT</version>
+        <version>5.4.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>org.wso2.carbon.identity.application.auth.basic</groupId>
     <modelVersion>4.0.0</modelVersion>
-    <version>5.3.8-SNAPSHOT</version>
+    <version>5.4.0-SNAPSHOT</version>
     <artifactId>identity-application-auth-basicauth</artifactId>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - BasicAuth Identity Application Authenticator Module</name>
@@ -46,6 +46,7 @@
     <modules>
         <module>components/org.wso2.carbon.identity.application.authenticator.basicauth</module>
         <module>features/org.wso2.carbon.identity.application.authenticator.basicauth.server.feature</module>
+        <module>components/org.wso2.carbon.identity.application.authenticator.basicauth.jwt</module>
     </modules>
 
     <dependencyManagement>
@@ -133,6 +134,34 @@
                 <artifactId>org.wso2.carbon.identity.application.authenticator.basicauth</artifactId>
                 <version>${project.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>${commons-logging.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-lang.wso2</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>${commons-lang.wso2.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wso2.orbit.com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>${nimbusds.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${json-smart.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.googlecode.json-simple.wso2</groupId>
+                <artifactId>json-simple</artifactId>
+                <version>${json-simple.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.jacoco</groupId>
                 <artifactId>org.jacoco.agent</artifactId>
@@ -339,6 +368,7 @@
         <carbon.kernel.version>4.4.11</carbon.kernel.version>
         <carbon.kernel.imp.pkg.version.range>[4.4.0, 5.0.0)</carbon.kernel.imp.pkg.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
+        <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
         <carbon.identity.framework.version>5.7.0</carbon.identity.framework.version>
@@ -354,8 +384,15 @@
         <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>
 
         <!-- Commons version-->
+        <commons-logging.version>1.2</commons-logging.version>
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
+        <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
+
+        <nimbusds.version>5.8.0.wso2v1</nimbusds.version>
+        <nimbusds.imp.pkg.version.range>[5.8.0,6.0.0)</nimbusds.imp.pkg.version.range>
+        <json-simple.version>1.1.wso2v1</json-simple.version>
+        <json-smart.version>1.3</json-smart.version>
 
         <!-- Maven plugin version -->
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>


### PR DESCRIPTION
## Purpose
Resolves wso2/product-is#3316
This PR introduces the authenticator that validate the JWT issued by the resident IdP for the username and password

## Goals
This authenticator is introduced to support authentication over a backchannel mechanism, without posting user credentials over the user agent. 
Therefore, a JWT received by authenticating via the backend API can be validated over this authenticator in the authentication flow.

## Approach
The authenticator validates a JWT issued by the resident IdP. If the JWT is valid (JWT signature is valid, JWT is not expired, JWT is not replayed), the subject mentioned in the JWT is picked as the authenticated user
