### PR TITLE
Update dependency version range of basic authenticator for jwt based basic authenticator.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,7 +361,7 @@
         <!-- Identity Local Auth BasicAuth version -->
         <identity.application.auth.basicauth.exp.pkg.version>${project.version}
         </identity.application.auth.basicauth.exp.pkg.version>
-        <identity.application.auth.basicauth.imp.pkg.version.range>[5.0.0, 6.0.0)
+        <identity.application.auth.basicauth.imp.pkg.version.range>[5.0.0, 7.0.0)
         </identity.application.auth.basicauth.imp.pkg.version.range>
 
         <!-- Carbon Kernel version -->


### PR DESCRIPTION

## Purpose
As the group id of JWT basic authenticator was changed the repository released version was upgraded to a major version (6.0.0). This released the basic authenticator 6.0.0 as well, even without any API changes.
So, now the JWT basic authenticator could depend on basic authenticator versions of 5.0.x and 6.0.x  as basic authenticator 6.0.x also didn't include any API changes.
Therefore the dependent basic authenticator version range was changed to include 6.0.x versions as well.
