### PR TITLE
Fix non-existing user logging scenarios

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -340,12 +340,12 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
             if (log.isDebugEnabled()) {
                 log.debug("BasicAuthentication failed while trying to get the tenant ID of the user " + username, e);
             }
-            throw new AuthenticationFailedException(e.getMessage(), User.getUserFromUserName(username), e);
+            throw new AuthenticationFailedException(e.getMessage(), e);
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             if (log.isDebugEnabled()) {
                 log.debug("BasicAuthentication failed while trying to authenticate", e);
             }
-            throw new AuthenticationFailedException(e.getMessage(), User.getUserFromUserName(username), e);
+            throw new AuthenticationFailedException(e.getMessage(), e);
         }
 
         if (!isAuthenticated) {

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -343,7 +343,7 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
             throw new AuthenticationFailedException(e.getMessage(), e);
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             if (log.isDebugEnabled()) {
-                log.debug("BasicAuthentication failed while trying to authenticate", e);
+                log.debug("BasicAuthentication failed while trying to authenticate the user " + username, e);
             }
             throw new AuthenticationFailedException(e.getMessage(), e);
         }


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/4724.

## Purpose
> - For a non-existing user, a failed login attempt should not represent a User. An example for this scenario would be a user trying to login with a non-existing tenant domain.  
> - Therefore, in a non-existing user login failed scenario, the login failed event published to the analytics, shoud not contain a User object having non-existing credentials.

## Goals
> - The authentication failed exception thrown for a non-existing user login scenario cannot contain a User object having non-existing user creadentials, as extracting a non-existing user from this exception is incorrect. 

## Approach
> Use a method signature for the authentication failed exception, which does not include the User, for non-existing user login scenarios.

## Documentation
> N/A