### PR TITLE
Enable recaptcha always for basic authentication if configured

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/pom.xml
@@ -61,6 +61,14 @@
             <artifactId>org.wso2.carbon.identity.application.common</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.captcha</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.governance</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -124,7 +132,11 @@
                             org.wso2.carbon.user.core; version="${carbon.kernel.imp.pkg.version.range}",
                             org.wso2.carbon.user.core.service; version="${carbon.kernel.imp.pkg.version.range}",
                             org.wso2.carbon.user.core.util; version="${carbon.kernel.imp.pkg.version.range}",
-                            org.wso2.carbon.utils.multitenancy; version="${carbon.kernel.imp.pkg.version.range}"
+                            org.wso2.carbon.utils.multitenancy; version="${carbon.kernel.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.captcha.connector.recaptcha; version="${identity.governance.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.captcha.util; version="${identity.governance.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.governance; version="${identity.governance.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.governance.common; version="${identity.governance.imp.pkg.version.range}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.application.authenticator.basicauth.internal,

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
@@ -39,7 +39,12 @@ public abstract class BasicAuthenticatorConstants {
     public static final String CONF_SHOW_AUTH_FAILURE_REASON = "showAuthFailureReason";
     public static final String CONF_MASK_USER_NOT_EXISTS_ERROR_CODE = "maskUserNotExistsErrorCode";
     public static final String CONF_ERROR_PARAMS_TO_OMIT = "errorParamsToOmit";
-    
+    public static final String AUTH_FAILURE_PARAM = "&authFailure=";
+    public static final String AUTH_FAILURE_MSG_PARAM = "&authFailureMsg=";
+    public static final String RECAPTCHA_PARAM = "&reCaptcha=";
+    public static final String RECAPTCHA_KEY_PARAM = "&reCaptchaKey=";
+    public static final String RECAPTCHA_API_PARAM = "&reCaptchaAPI=";
+
     private BasicAuthenticatorConstants() {
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorDataHolder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorDataHolder.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authenticator.basicauth.internal;
+
+import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+
+import java.util.Properties;
+
+/**
+ * Holds services and data required for the Basic Authenticator.
+ */
+public class BasicAuthenticatorDataHolder {
+
+    private static BasicAuthenticatorDataHolder instance = new BasicAuthenticatorDataHolder();
+
+    private IdentityGovernanceService identityGovernanceService;
+
+    private Properties recaptchaConfigs;
+
+    private BasicAuthenticatorDataHolder() {
+
+    }
+
+    public static BasicAuthenticatorDataHolder getInstance() {
+        return instance;
+    }
+
+    public IdentityGovernanceService getIdentityGovernanceService() {
+        return identityGovernanceService;
+    }
+
+    public void setIdentityGovernanceService(IdentityGovernanceService identityGovernanceService) {
+        this.identityGovernanceService = identityGovernanceService;
+    }
+
+    public Properties getRecaptchaConfigs() {
+        return recaptchaConfigs;
+    }
+
+    public void setRecaptchaConfigs(Properties recaptchaConfigs) {
+        this.recaptchaConfigs = recaptchaConfigs;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,16 @@
                 <artifactId>json-simple</artifactId>
                 <version>${json-simple.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.wso2.carbon.identity.governance</groupId>
+                <artifactId>org.wso2.carbon.identity.captcha</artifactId>
+                <version>${identity.governance.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.governance</groupId>
+                <artifactId>org.wso2.carbon.identity.governance</artifactId>
+                <version>${identity.governance.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.jacoco</groupId>
                 <artifactId>org.jacoco.agent</artifactId>
@@ -380,9 +389,12 @@
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.14.67</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.14.78</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
+
+        <identity.governance.version>1.3.23</identity.governance.version>
+        <identity.governance.imp.pkg.version.range>[1.3.0, 2.0.0)</identity.governance.imp.pkg.version.range>
 
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -393,8 +393,8 @@
         <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
-        <identity.governance.version>1.3.23</identity.governance.version>
-        <identity.governance.imp.pkg.version.range>[1.3.0, 2.0.0)</identity.governance.imp.pkg.version.range>
+        <identity.governance.version>1.3.28</identity.governance.version>
+        <identity.governance.imp.pkg.version.range>[1.3.28, 2.0.0)</identity.governance.imp.pkg.version.range>
 
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>


### PR DESCRIPTION
## Purpose
This PR will add the parameters required to enable the Recaptcha when loading the basic authenticator login page. 

## Approach
* When redirecting to the login page, the authenticator will check whether the Recaptcha is always enabled for the authentication from the Login Policies. (This additional configuration capability is introduced with the PR,https://github.com/wso2-extensions/identity-governance/pull/335
* If this is enabled, Basic authenticator will get the Recaptcha configs from the captcha-config.properties file.
* Then add the following parameters in the redirect UI.
** &reCaptcha
** &reCaptchaKey
** &reCaptchaAPI


## Documentation
Documents need to be updated with the new config details.

## Automation tests
 - Unit tests provided

## Related PRs
Merge this PR after https://github.com/wso2-extensions/identity-governance/pull/335 and bumping the governance version

Fixes, https://github.com/wso2/product-is/issues/6848

