### PR TITLE
Redirect to application login page after offline password reset

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/pom.xml
@@ -69,6 +69,10 @@
             <artifactId>org.wso2.carbon.identity.governance</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.recovery</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -137,6 +141,7 @@
                             org.wso2.carbon.identity.captcha.connector.recaptcha; version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.captcha.util; version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.governance; version="${identity.governance.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.recovery; version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.governance.common; version="${identity.governance.imp.pkg.version.range}"
                         </Import-Package>
                         <Export-Package>

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -46,6 +46,7 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
 import org.wso2.carbon.identity.governance.common.IdentityConnectorConfig;
+import org.wso2.carbon.identity.recovery.RecoveryScenarios;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreException;
@@ -227,11 +228,20 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                         IdentityCoreConstants.ADMIN_FORCED_USER_PASSWORD_RESET_VIA_OTP_ERROR_CODE)) {
                     String username = request.getParameter(BasicAuthenticatorConstants.USER_NAME);
                     String tenantDoamin = MultitenantUtils.getTenantDomain(username);
+
+                    String reason = BasicAuthenticatorConstants.REASON_PARAM +
+                            RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP.name();
+                    // Setting callback so that the user is prompted to login after a password reset.
+                    String callback = loginPage + ("?" + queryParams)
+                            + BasicAuthenticatorConstants.AUTHENTICATORS + getName() + ":" +
+                            BasicAuthenticatorConstants.LOCAL + reason;
+
                     redirectURL = (PASSWORD_RESET_ENDPOINT + queryParams) +
                             BasicAuthenticatorConstants.USER_NAME_PARAM + URLEncoder.encode(username, BasicAuthenticatorConstants.UTF_8) +
                             BasicAuthenticatorConstants.TENANT_DOMAIN_PARAM + URLEncoder.encode(tenantDoamin, BasicAuthenticatorConstants.UTF_8) +
-                            BasicAuthenticatorConstants.CONFIRMATION_PARAM + URLEncoder.encode(password, BasicAuthenticatorConstants.UTF_8);
-
+                            BasicAuthenticatorConstants.CONFIRMATION_PARAM + URLEncoder.encode(password,
+                            BasicAuthenticatorConstants.UTF_8) + BasicAuthenticatorConstants.CALLBACK_PARAM +
+                            URLEncoder.encode(callback, BasicAuthenticatorConstants.UTF_8);
                 } else if ("true".equals(showAuthFailureReason)) {
 
                     if (Boolean.parseBoolean(maskUserNotExistsErrorCode) &&

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -229,19 +229,20 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                     String username = request.getParameter(BasicAuthenticatorConstants.USER_NAME);
                     String tenantDoamin = MultitenantUtils.getTenantDomain(username);
 
-                    String reason = BasicAuthenticatorConstants.REASON_PARAM +
-                            RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP.name();
                     // Setting callback so that the user is prompted to login after a password reset.
                     String callback = loginPage + ("?" + queryParams)
                             + BasicAuthenticatorConstants.AUTHENTICATORS + getName() + ":" +
-                            BasicAuthenticatorConstants.LOCAL + reason;
+                            BasicAuthenticatorConstants.LOCAL;
+                    String reason = RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP.name();
 
                     redirectURL = (PASSWORD_RESET_ENDPOINT + queryParams) +
                             BasicAuthenticatorConstants.USER_NAME_PARAM + URLEncoder.encode(username, BasicAuthenticatorConstants.UTF_8) +
                             BasicAuthenticatorConstants.TENANT_DOMAIN_PARAM + URLEncoder.encode(tenantDoamin, BasicAuthenticatorConstants.UTF_8) +
                             BasicAuthenticatorConstants.CONFIRMATION_PARAM + URLEncoder.encode(password,
                             BasicAuthenticatorConstants.UTF_8) + BasicAuthenticatorConstants.CALLBACK_PARAM +
-                            URLEncoder.encode(callback, BasicAuthenticatorConstants.UTF_8);
+                            URLEncoder.encode(callback, BasicAuthenticatorConstants.UTF_8) +
+                            BasicAuthenticatorConstants.REASON_PARAM +
+                            URLEncoder.encode(reason, BasicAuthenticatorConstants.UTF_8);
                 } else if ("true".equals(showAuthFailureReason)) {
 
                     if (Boolean.parseBoolean(maskUserNotExistsErrorCode) &&

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
@@ -46,6 +46,8 @@ public abstract class BasicAuthenticatorConstants {
     public static final String RECAPTCHA_PARAM = "&reCaptcha=";
     public static final String RECAPTCHA_KEY_PARAM = "&reCaptchaKey=";
     public static final String RECAPTCHA_API_PARAM = "&reCaptchaAPI=";
+    public static final String CALLBACK_PARAM = "&callback=";
+    public static final String REASON_PARAM = "&reason=";
 
     private BasicAuthenticatorConstants() {
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
@@ -121,9 +121,7 @@ public class BasicAuthenticatorTestCase extends PowerMockIdentityBaseTest {
     private String dummyDomainName = "dummyDomain";
     private String dummyRetryURL = "DummyRetryUrl";
     private String dummyEncodedVal = "DummyRetryUrl?dummyQueryParams";
-    private String callback =
-            dummyLoginPage + "?" + dummyQueryParam + "&authenticators=BasicAuthenticator:LOCAL&reason=" +
-                    RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP.name();
+    private String callback = dummyLoginPage + "?" + dummyQueryParam + "&authenticators=BasicAuthenticator";
 
     private BasicAuthenticator basicAuthenticator;
 
@@ -754,7 +752,10 @@ public class BasicAuthenticatorTestCase extends PowerMockIdentityBaseTest {
                                 URLEncoder.encode(super_tenant, BasicAuthenticatorConstants.UTF_8) +
                                 BasicAuthenticatorConstants.CONFIRMATION_PARAM + URLEncoder.encode(dummyPassword,
                                 BasicAuthenticatorConstants.UTF_8) + BasicAuthenticatorConstants.CALLBACK_PARAM +
-                                URLEncoder.encode(callback, BasicAuthenticatorConstants.UTF_8), "1", "1"
+                                URLEncoder.encode(callback, BasicAuthenticatorConstants.UTF_8) +
+                                BasicAuthenticatorConstants.REASON_PARAM +
+                                URLEncoder.encode(RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP.name(),
+                                        BasicAuthenticatorConstants.UTF_8), "1", "1"
                 }
         };
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
@@ -50,6 +50,7 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.governance.IdentityGovernanceException;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
+import org.wso2.carbon.identity.recovery.RecoveryScenarios;
 import org.wso2.carbon.identity.testutil.powermock.PowerMockIdentityBaseTest;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.api.UserRealm;
@@ -120,6 +121,9 @@ public class BasicAuthenticatorTestCase extends PowerMockIdentityBaseTest {
     private String dummyDomainName = "dummyDomain";
     private String dummyRetryURL = "DummyRetryUrl";
     private String dummyEncodedVal = "DummyRetryUrl?dummyQueryParams";
+    private String callback =
+            dummyLoginPage + "?" + dummyQueryParam + "&authenticators=BasicAuthenticator:LOCAL&reason=" +
+                    RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP.name();
 
     private BasicAuthenticator basicAuthenticator;
 
@@ -740,6 +744,17 @@ public class BasicAuthenticatorTestCase extends PowerMockIdentityBaseTest {
                         BasicAuthenticatorConstants.USER_NAME_PARAM + URLEncoder.encode(dummyUserName, BasicAuthenticatorConstants.UTF_8) +
                         BasicAuthenticatorConstants.TENANT_DOMAIN_PARAM + URLEncoder.encode(super_tenant, BasicAuthenticatorConstants.UTF_8) +
                         BasicAuthenticatorConstants.CONFIRMATION_PARAM + URLEncoder.encode(dummyPassword, BasicAuthenticatorConstants.UTF_8), "1", "1"
+                },
+                {
+                        IdentityCoreConstants.ADMIN_FORCED_USER_PASSWORD_RESET_VIA_OTP_ERROR_CODE,
+                        "accountrecoveryendpoint/confirmrecovery.do?" + dummyQueryParam +
+                                BasicAuthenticatorConstants.USER_NAME_PARAM +
+                                URLEncoder.encode(dummyUserName, BasicAuthenticatorConstants.UTF_8) +
+                                BasicAuthenticatorConstants.TENANT_DOMAIN_PARAM +
+                                URLEncoder.encode(super_tenant, BasicAuthenticatorConstants.UTF_8) +
+                                BasicAuthenticatorConstants.CONFIRMATION_PARAM + URLEncoder.encode(dummyPassword,
+                                BasicAuthenticatorConstants.UTF_8) + BasicAuthenticatorConstants.CALLBACK_PARAM +
+                                URLEncoder.encode(callback, BasicAuthenticatorConstants.UTF_8), "1", "1"
                 }
         };
     }
@@ -986,8 +1001,8 @@ public class BasicAuthenticatorTestCase extends PowerMockIdentityBaseTest {
 
     private void validateResponseParams(String expected, String actual) throws URISyntaxException {
 
-        URI expectedURI = new URI(URLDecoder.decode(expected));
-        String[] expectedQueryParams = expectedURI.getQuery().split("&");
+        URI expectedURI = new URI(expected);
+        String[] expectedQueryParams = expected.split("&");
 
         for (String expectedQueryParam : expectedQueryParams) {
             if (!actual.contains(expectedQueryParam)) {

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,11 @@
                 <version>${identity.governance.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.governance</groupId>
+                <artifactId>org.wso2.carbon.identity.recovery</artifactId>
+                <version>${identity.governance.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jacoco</groupId>
                 <artifactId>org.jacoco.agent</artifactId>
                 <classifier>runtime</classifier>


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/8525
## Purpose
Setting the callback param to the login page in the request so that the user is prompted to login after the password reset.

Added a new param `reason` to the callback URI so that scenario can be passed in the request. In this scenario, the `reason` would be as follows.

```
&reason=ADMIN_FORCED_PASSWORD_RESET_VIA_OTP
```

## Tests
Improved the unit tests to support new improvement.