### PR TITLE
 Fix for the remainingAttempts query parameter not returning issue

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
@@ -49,6 +49,8 @@ public abstract class BasicAuthenticatorConstants {
     public static final String CALLBACK_PARAM = "&callback=";
     public static final String REASON_PARAM = "&reason=";
 
+    public static final String AUTHENTICATION_POLICY_CONFIG = "AuthenticationPolicy.CheckAccountExist";
+
     private BasicAuthenticatorConstants() {
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
@@ -91,6 +91,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
 
 /**
  * Unit test cases for the Basic Authenticator.
@@ -428,6 +429,17 @@ public class BasicAuthenticatorTestCase extends PowerMockIdentityBaseTest {
                 return null;
             }
         }).when(mockAuthnCtxt).setRememberMe(anyBoolean());
+
+        Map<String, Object> mockedThreadLocalMap = new HashMap<>();
+        mockedThreadLocalMap.put("userExistThreadLocalProperty", false);
+        IdentityUtil.threadLocalProperties.set(mockedThreadLocalMap);
+
+        when(IdentityUtil.getProperty(BasicAuthenticatorConstants.AUTHENTICATION_POLICY_CONFIG)).
+                thenReturn("true");
+        IdentityErrorMsgContext customErrorMessageContext = new IdentityErrorMsgContext(UserCoreConstants
+                .ErrorCode.USER_DOES_NOT_EXIST);
+        ThreadLocal<IdentityErrorMsgContext> IdentityError = new ThreadLocal();
+        IdentityError.set(customErrorMessageContext);
 
         basicAuthenticator.processAuthenticationResponse(mockRequest, mockResponse, mockAuthnCtxt);
 


### PR DESCRIPTION
## Description
 Fix for the remainingAttempts query parameter not returning issue for the users in the secondary user store.

## Approach
Maintain the state of the user existence through `userExistThreadLocalProperty` to set the error code to IdentityErrorMsgContext accordingly based on the "user does not exist" and "invalid credentials" cases.

Resolves: wso2/product-is#9583
Related PR: https://github.com/wso2-extensions/identity-governance/pull/436