### PR TITLE
Provide option to skip pre-processing identifier using adaptive script

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -438,7 +438,8 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
         Map<String, String> runtimeParams = getRuntimeParams(context);
         if (runtimeParams != null) {
             String usernameFromContext = runtimeParams.get(FrameworkConstants.JSAttributes.JS_OPTIONS_USERNAME);
-            if (usernameFromContext != null && !usernameFromContext.equals(username)) {
+            if (usernameFromContext != null &&
+                    !usernameFromContext.equals(request.getParameter(BasicAuthenticatorConstants.USER_NAME))) {
                 if (log.isDebugEnabled()) {
                     log.debug("Username set for identifier first login: " + usernameFromContext + " and username " +
                             "submitted from login page" + username + " does not match.");


### PR DESCRIPTION
## Purpose
> Provide option to skip pre-processing identifier using the adaptive script. 

```
executeStep(1,{
        authenticatorParams : {
                                  common : {
                                       'skipIdentifierPreProcess' : "true"
                                    }
                                }
        } ,{});
```

## Goals
> If needed we can skip processing the identifier provided in the identifier-first. So we can process it in the adaptive script level.

