### PR TITLE
Set user store domain thread local in auto login flow

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -155,6 +155,12 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
         }
 
         validateCookieSignature(content, signature, alias);
+
+        String userStoreDomain = UserCoreUtil.extractDomainFromName(usernameInCookie);
+        // Set the user store domain in thread local as downstream code depends on it. This will be cleared at the
+        // end of the request at the framework.
+        UserCoreUtil.setDomainInThreadLocal(userStoreDomain);
+
         usernameInCookie = FrameworkUtils.prependUserStoreDomainToName(usernameInCookie);
 
         String tenantDomain = MultitenantUtils.getTenantDomain(usernameInCookie);


### PR DESCRIPTION
Downstream code expects the user store domain to be set in the thread-local. This thread-local usually gets populated during any user store operation
at the user store layer. In the auto-login flow, we do not call any user store operations hence the thread-local will not be set.

As a solution, we set the thread-local explicitly. The value for the user store domain is expected to be set in the cookie.

