### PR TITLE
Fix invalid tenant selecting for redirecting with reCaptcha options

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -450,7 +450,7 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                         BasicAuthenticatorConstants.LOCAL + retryParam;
             }
 
-            redirectURL += getCaptchaParams(context.getTenantDomain());
+            redirectURL += getCaptchaParams(context.getUserTenantDomain());
             response.sendRedirect(redirectURL);
         } catch (IOException e) {
             throw new AuthenticationFailedException(ErrorMessages.SYSTEM_ERROR_WHILE_AUTHENTICATING.getCode(),


### PR DESCRIPTION
## Purpose
> Fix showing reCaptcha prompt for tenant users when `isTenantedSessionsEnabled` is true when reCaptcha is always enabled for super tenant.

## Approach
> Use `getUserTenantDomain` method of `AuthenticationContext` instead of `getTenantDomain` method for selecting the tenant.