### PR TITLE
Add secure vault support for recaptcha configs

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/pom.xml
@@ -115,7 +115,11 @@
             <artifactId>org.wso2.carbon.identity.multi.attribute.login.mgt</artifactId>
             <version>${carbon.identity.framework.version}</version>
         </dependency>
-        </dependencies>
+        <dependency>
+            <groupId>org.wso2.securevault</groupId>
+            <artifactId>org.wso2.securevault</artifactId>
+        </dependency>
+    </dependencies>
     <build>
         <plugins>
             <plugin>
@@ -166,6 +170,7 @@
                             org.wso2.carbon.identity.multi.attribute.login.mgt.*;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.user.core.*; version="${carbon.kernel.imp.pkg.version.range}",
+                            org.wso2.securevault.*; version="${org.wso2.securevault.import.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.application.authenticator.basicauth.internal,

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorServiceComponentTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorServiceComponentTestCase.java
@@ -17,15 +17,19 @@
  */
 package org.wso2.carbon.identity.application.authenticator.basicauth.internal;
 
+import org.mockito.Mockito;
 import org.osgi.service.component.ComponentContext;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.testutil.IdentityBaseTest;
 import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.securevault.SecretResolverFactory;
 
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.testng.Assert.assertNotNull;
 
+@PrepareForTest(SecretResolverFactory.class)
 public class BasicAuthenticatorServiceComponentTestCase extends IdentityBaseTest {
 
     private RealmService mockRealmService;
@@ -55,5 +59,13 @@ public class BasicAuthenticatorServiceComponentTestCase extends IdentityBaseTest
     public void unSetRealmTestCase() throws NoSuchFieldException, IllegalAccessException {
         mockRealmService = mock(RealmService.class);
         basicAuthenticatorServiceComponent.unsetRealmService(mockRealmService);
+    }
+
+    @Test
+    public void activateTestCase() {
+        ComponentContext componentContext = mock(ComponentContext.class, Mockito.RETURNS_DEEP_STUBS);
+        basicAuthenticatorServiceComponent.activate(componentContext);
+
+        Mockito.verify(componentContext, Mockito.atLeastOnce()).getBundleContext();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,12 @@
                 <artifactId>pax-logging-api</artifactId>
                 <version>${pax.logging.api.version}</version>
             </dependency>
-            </dependencies>
+            <dependency>
+                <groupId>org.wso2.securevault</groupId>
+                <artifactId>org.wso2.securevault</artifactId>
+                <version>${org.wso2.securevault.version}</version>
+            </dependency>
+        </dependencies>
     </dependencyManagement>
 
     <repositories>
@@ -436,6 +441,9 @@
 
         <!-- Pax Logging Version -->
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
+
+        <org.wso2.securevault.version>1.1.3</org.wso2.securevault.version>
+        <org.wso2.securevault.import.version.range>[1.1.0, 2.0.0)</org.wso2.securevault.import.version.range>
     </properties>
 
 </project>


### PR DESCRIPTION
### Proposed changes in this pull request

Adding secure vault support for reCaptcha `site-key`, `site-secret` or any other captcha property. 

Partially resolves : https://github.com/wso2/product-is/issues/11693