### PR TITLE
Add backward compatibility to #71

### DIFF
--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
@@ -332,8 +332,11 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
             }
         }
 
-        FrameworkUtils.validateUsername(identifierFromRequest, context);
-        String username = FrameworkUtils.preprocessUsername(identifierFromRequest, context);
+        String username = identifierFromRequest;
+        if (!IdentityUtil.isEmailUsernameValidationDisabled()) {
+            FrameworkUtils.validateUsername(identifierFromRequest, context);
+            username = FrameworkUtils.preprocessUsername(identifierFromRequest, context);
+        }
 
         String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
         String userId = null;

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -464,7 +464,6 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
             throws AuthenticationFailedException {
 
         String loginIdentifierFromRequest = request.getParameter(BasicAuthenticatorConstants.USER_NAME);
-        FrameworkUtils.validateUsername(loginIdentifierFromRequest, context);
         Map<String, String> runtimeParams = getRuntimeParams(context);
         if (runtimeParams != null) {
             // FrameworkUtils.preprocessUsername will not append the tenant domain to username, if you are using
@@ -476,7 +475,13 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                 loginIdentifierFromRequest = loginIdentifierFromRequest + "@" + context.getUserTenantDomain();
             }
         }
-        String username = FrameworkUtils.preprocessUsername(loginIdentifierFromRequest, context);
+
+        String username = loginIdentifierFromRequest;
+        if (!IdentityUtil.isEmailUsernameValidationDisabled()) {
+            FrameworkUtils.validateUsername(loginIdentifierFromRequest, context);
+            username = FrameworkUtils.preprocessUsername(loginIdentifierFromRequest, context);
+        }
+
         String requestTenantDomain = MultitenantUtils.getTenantDomain(username);
         String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
         String userId = null;

--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.20.66</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.94</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.19.14, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
Resolves partially https://github.com/wso2/product-is/issues/10760
Depends on https://github.com/wso2/carbon-identity-framework/pull/3582

## Purpose
This fix is to add backward compatibility support to https://github.com/wso2-extensions/identity-local-auth-basicauth/pull/71
