### PR TITLE
Add support to show the Account Locked error message on the login page

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -404,10 +404,9 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                             paramMap.put(BasicAuthenticatorConstants.REMAINING_ATTEMPTS, "0");
                         }
                         if (Boolean.parseBoolean(showAuthFailureReasonOnLoginPage)) {
-                            retryParam = retryParam + buildErrorParamString(paramMap);
                             redirectURL = loginPage + ("?" + queryParams)
                                     + BasicAuthenticatorConstants.AUTHENTICATORS + getName() + ":" +
-                                    BasicAuthenticatorConstants.LOCAL + retryParam;
+                                    BasicAuthenticatorConstants.LOCAL + buildErrorParamString(paramMap);
                         } else {
                             redirectURL = response.encodeRedirectURL(retryPage + ("?" + queryParams))
                                     + buildErrorParamString(paramMap);

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -200,6 +200,7 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
 
         Map<String, String> parameterMap = getAuthenticatorConfig().getParameterMap();
         String showAuthFailureReason = null;
+        String showAuthFailureReasonOnLoginPage = null;
         String maskUserNotExistsErrorCode = null;
         String maskAdminForcedPasswordResetErrorCode = null;
         if (parameterMap != null) {
@@ -215,7 +216,12 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                     log.debug(BasicAuthenticatorConstants.CONF_MASK_USER_NOT_EXISTS_ERROR_CODE +
                             " has been set as : " + maskUserNotExistsErrorCode);
                 }
-
+                showAuthFailureReasonOnLoginPage =
+                        parameterMap.get(BasicAuthenticatorConstants.CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE);
+                if (log.isDebugEnabled()) {
+                    log.debug(BasicAuthenticatorConstants.CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE +
+                            " has been set as : " + showAuthFailureReasonOnLoginPage);
+                }
                 String errorParamsToOmit = parameterMap.get(BasicAuthenticatorConstants.CONF_ERROR_PARAMS_TO_OMIT);
                 if (log.isDebugEnabled()) {
                     log.debug(BasicAuthenticatorConstants.CONF_ERROR_PARAMS_TO_OMIT + " has been set as : " +
@@ -397,9 +403,15 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                         if (remainingAttempts == 0) {
                             paramMap.put(BasicAuthenticatorConstants.REMAINING_ATTEMPTS, "0");
                         }
-
-                        redirectURL = response.encodeRedirectURL(retryPage + ("?" + queryParams))
-                                + buildErrorParamString(paramMap);
+                        if (Boolean.parseBoolean(showAuthFailureReasonOnLoginPage)) {
+                            retryParam = retryParam + buildErrorParamString(paramMap);
+                            redirectURL = loginPage + ("?" + queryParams)
+                                    + BasicAuthenticatorConstants.AUTHENTICATORS + getName() + ":" +
+                                    BasicAuthenticatorConstants.LOCAL + retryParam;
+                        } else {
+                            redirectURL = response.encodeRedirectURL(retryPage + ("?" + queryParams))
+                                    + buildErrorParamString(paramMap);
+                        }
                     } else if (errorCode.equals(
                             IdentityCoreConstants.ADMIN_FORCED_USER_PASSWORD_RESET_VIA_OTP_MISMATCHED_ERROR_CODE)) {
                         Map<String, String> paramMap = new HashMap<>();

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
@@ -37,6 +37,7 @@ public abstract class BasicAuthenticatorConstants {
     public static final String REMAINING_ATTEMPTS = "&remainingAttempts=";
     public static final String LOCKED_REASON = "&lockedReason=";
     public static final String CONF_SHOW_AUTH_FAILURE_REASON = "showAuthFailureReason";
+    public static final String CONF_SHOW_AUTH_FAILURE_REASON_ON_LOGIN_PAGE = "showAuthFailureReasonOnLoginPage";
     public static final String CONF_MASK_USER_NOT_EXISTS_ERROR_CODE = "maskUserNotExistsErrorCode";
     public static final String CONF_MASK_ADMIN_FORCED_PASSWORD_RESET_ERROR_CODE =
             "maskAdminForcedPasswordResetErrorCode";


### PR DESCRIPTION
## Purpose
Resolves: [wso2/product-is/issues/12175](https://github.com/wso2/product-is/issues/12175)

>  Currently, there is no proper indication for the user that his account is locked due to reaching the maximum failed login attempts. 

>Introduced a new toml property(**showAuthFailureReasonOnLoginPage**) to show account locked error message on the login page.

>This property is connected with the **showAuthFailureReason** property.
```
[authentication.authenticator.basic.parameters]
showAuthFailureReason = true
showAuthFailureReasonOnLoginPage = true
```
Enabling both properties in the deployment.toml, the account locked error message will be displayed on the login page.

![Screenshot from 2021-07-23 00-08-02](https://user-images.githubusercontent.com/36721128/126912291-d3f2d648-3073-4186-9b24-887cfba05840.png)

## Related PRs
[wso2/identity-apps/pull/2257](https://github.com/wso2/identity-apps/pull/2257)
[wso2/carbon-identity-framework/pull/3622](https://github.com/wso2/carbon-identity-framework/pull/3622)

