### PR TITLE
Redirect to error page when non-approved users are trying to login

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -346,6 +346,16 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                             URLEncoder.encode(callback, BasicAuthenticatorConstants.UTF_8) +
                             BasicAuthenticatorConstants.REASON_PARAM +
                             URLEncoder.encode(reason, BasicAuthenticatorConstants.UTF_8);
+                } else if (errorCode.equals(
+                        IdentityCoreConstants.USER_ACCOUNT_PENDING_APPROVAL_ERROR_CODE)) {
+                    retryParam = BasicAuthenticatorConstants.AUTH_FAILURE_PARAM + "true" +
+                            BasicAuthenticatorConstants.AUTH_FAILURE_MSG_PARAM + "account.pending.approval";
+                    String username = request.getParameter(BasicAuthenticatorConstants.USER_NAME);
+
+                    redirectURL = loginPage + ("?" + queryParams) + BasicAuthenticatorConstants.FAILED_USERNAME
+                            + URLEncoder.encode(username, BasicAuthenticatorConstants.UTF_8) +
+                            BasicAuthenticatorConstants.ERROR_CODE + errorCode + BasicAuthenticatorConstants
+                            .AUTHENTICATORS + getName() + ":" + BasicAuthenticatorConstants.LOCAL + retryParam;
                 } else if ("true".equals(showAuthFailureReason)) {
 
                     if (Boolean.parseBoolean(maskUserNotExistsErrorCode) &&

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
@@ -1187,6 +1187,16 @@ public class BasicAuthenticatorTestCase {
                                 BasicAuthenticatorConstants.REASON_PARAM +
                                 URLEncoder.encode(RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP.name(),
                                         BasicAuthenticatorConstants.UTF_8), "1", "1"
+                },
+                {
+                        IdentityCoreConstants.USER_ACCOUNT_PENDING_APPROVAL_ERROR_CODE,
+                        DUMMY_LOGIN_PAGEURL + "?" + DUMMY_QUERY_PARAMS + BasicAuthenticatorConstants.FAILED_USERNAME
+                                + URLEncoder.encode(DUMMY_USER_NAME, BasicAuthenticatorConstants.UTF_8) +
+                                BasicAuthenticatorConstants.ERROR_CODE +
+                                IdentityCoreConstants.USER_ACCOUNT_PENDING_APPROVAL_ERROR_CODE +
+                                BasicAuthenticatorConstants.AUTHENTICATORS + BasicAuthenticatorConstants.
+                                AUTHENTICATOR_NAME + ":" + BasicAuthenticatorConstants.LOCAL +
+                                "&authFailure=true&authFailureMsg=account.pending.approval", "1", "1"
                 }
         };
     }

--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.20.206</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.208</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.19.14, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose
This PR change, will fix the issue of not showing proper error messages in the UI when not approved users are trying to log in when the 'Add User' workflow operation is engaged.

Resolves: wso2/product-is#12462

### When should this PR be merged
After merging https://github.com/wso2/carbon-identity-framework/pull/3759 and upgrading the framework version