### PR TITLE
Remove redundant queryparams from redirect URL in admin forced password reset offline flow

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -328,7 +328,7 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                             BasicAuthenticatorConstants.LOCAL;
                     String reason = RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP.name();
 
-                    redirectURL = (PASSWORD_RESET_ENDPOINT + queryParams) +
+                    redirectURL = PASSWORD_RESET_ENDPOINT +
                             BasicAuthenticatorConstants.USER_NAME_PARAM + URLEncoder.encode(username,
                             BasicAuthenticatorConstants.UTF_8) + BasicAuthenticatorConstants.TENANT_DOMAIN_PARAM +
                             URLEncoder.encode(tenantDomain, BasicAuthenticatorConstants.UTF_8) +

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
@@ -31,7 +31,7 @@ public abstract class BasicAuthenticatorConstants {
     public static final String AUTHENTICATORS = "&authenticators=";
     public static final String LOCAL = "LOCAL";
     public static final String UTF_8 = "UTF-8";
-    public static final String USER_NAME_PARAM = "&username=";
+    public static final String USER_NAME_PARAM = "username=";
     public static final String TENANT_DOMAIN_PARAM = "&tenantdomain=";
     public static final String CONFIRMATION_PARAM = "&confirmation=";
     public static final String REMAINING_ATTEMPTS = "&remainingAttempts=";

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
@@ -1189,17 +1189,19 @@ public class BasicAuthenticatorTestCase {
                 },
                 {
                         IdentityCoreConstants.ADMIN_FORCED_USER_PASSWORD_RESET_VIA_OTP_ERROR_CODE,
-                        "accountrecoveryendpoint/confirmrecovery.do?" + DUMMY_QUERY_PARAMS
+                        "accountrecoveryendpoint/confirmrecovery.do?"
                                 + BasicAuthenticatorConstants.USER_NAME_PARAM
                                 + URLEncoder.encode(DUMMY_USER_NAME, BasicAuthenticatorConstants.UTF_8)
                                 + BasicAuthenticatorConstants.TENANT_DOMAIN_PARAM
                                 + URLEncoder.encode(super_tenant, BasicAuthenticatorConstants.UTF_8)
                                 + BasicAuthenticatorConstants.CONFIRMATION_PARAM
-                                + URLEncoder.encode(DUMMY_PASSWORD, BasicAuthenticatorConstants.UTF_8), "1", "1"
+                                + URLEncoder.encode(DUMMY_PASSWORD, BasicAuthenticatorConstants.UTF_8)
+                                + BasicAuthenticatorConstants.CALLBACK_PARAM
+                                + URLEncoder.encode(callback, BasicAuthenticatorConstants.UTF_8), "1", "1"
                 },
                 {
                         IdentityCoreConstants.ADMIN_FORCED_USER_PASSWORD_RESET_VIA_OTP_ERROR_CODE,
-                        "accountrecoveryendpoint/confirmrecovery.do?" + DUMMY_QUERY_PARAMS +
+                        "accountrecoveryendpoint/confirmrecovery.do?" +
                                 BasicAuthenticatorConstants.USER_NAME_PARAM +
                                 URLEncoder.encode(DUMMY_USER_NAME, BasicAuthenticatorConstants.UTF_8) +
                                 BasicAuthenticatorConstants.TENANT_DOMAIN_PARAM +


### PR DESCRIPTION
## Purpose

Resolves https://github.com/wso2/product-is/issues/12790

**admin forced password reset offline flow**

**Current behaviour**

IS already sends sp query params in the callbackURL param. So sending them again is redundant.
` 
https://localhost:9443/accountrecoveryendpoint/confirmrecovery.do?client_id=MY_ACCOUNT&code_challenge=ZC5SGiXr9vBZRWq6l2q72pSdeECMCAuQr1c2b66P7pg&code_challenge_method=S256&commonAuthCallerPath=%2Foauth2%2Fauthorize&forceAuth=false&passiveAuth=false&redirect_uri=https%3A%2F%2Flocalhost%3A9443%2Fmyaccount&response_mode=form_post&response_type=code&scope=openid+SYSTEM&tenantDomain=carbon.super&sessionDataKey=4b78f773-0b6e-410e-8897-abdaf8597166&relyingParty=MY_ACCOUNT&type=oidc&sp=My+Account&isSaaSApp=true&username=user1%40xyz.com&tenantdomain=xyz.com&confirmation=KCDOMS&callback=https%3A%2F%2Flocalhost%3A9443%2Fauthenticationendpoint%2Flogin.do%3Fclient_id%3DMY_ACCOUNT%26code_challenge%3DZC5SGiXr9vBZRWq6l2q72pSdeECMCAuQr1c2b66P7pg%26code_challenge_method%3DS256%26commonAuthCallerPath%3D%252Foauth2%252Fauthorize%26forceAuth%3Dfalse%26passiveAuth%3Dfalse%26redirect_uri%3Dhttps%253A%252F%252Flocalhost%253A9443%252Fmyaccount%26response_mode%3Dform_post%26response_type%3Dcode%26scope%3Dopenid%2BSYSTEM%26tenantDomain%3Dcarbon.super%26sessionDataKey%3D4b78f773-0b6e-410e-8897-abdaf8597166%26relyingParty%3DMY_ACCOUNT%26type%3Doidc%26sp%3DMy%2BAccount%26isSaaSApp%3Dtrue%26authenticators%3DBasicAuthenticator%3ALOCAL&reason=ADMIN_FORCED_PASSWORD_RESET_VIA_OTP
`

IS sends query params **two times**. One is after the **confirmrecovery.do** and then in the **callback param** as well. Due to this tenantDomain=carbon.super(sp tenant that should come in the callback URL) appears before the tenantdomain=xyz.com. SP tenant should not come in the query params, instead, it should come only in the callback.


**After this fix:**
`https://localhost:9443/accountrecoveryendpoint/confirmrecovery.do?username=user1%40xyz.com&tenantdomain=xyz.com&confirmation=R03S4I&callback=https%3A%2F%2Flocalhost%3A9443%2Fauthenticationendpoint%2Flogin.do%3Fclient_id%3DMY_ACCOUNT%26code_challenge%3DAqI0yviMvRDYv5XWEvP6UWHpmosEvG7qrKwAmpmYxqg%26code_challenge_method%3DS256%26commonAuthCallerPath%3D%252Foauth2%252Fauthorize%26forceAuth%3Dfalse%26passiveAuth%3Dfalse%26redirect_uri%3Dhttps%253A%252F%252Flocalhost%253A9443%252Fmyaccount%26response_mode%3Dform_post%26response_type%3Dcode%26scope%3Dopenid%2BSYSTEM%26tenantDomain%3Dcarbon.super%26sessionDataKey%3D7b61c82f-f14d-4af5-ab5d-4a3f61ce03d6%26relyingParty%3DMY_ACCOUNT%26type%3Doidc%26sp%3DMy%2BAccount%26isSaaSApp%3Dtrue%26authenticators%3DBasicAuthenticator%3ALOCAL&reason=ADMIN_FORCED_PASSWORD_RESET_VIA_OTP
`
In password recovery flow also, we send only callbackURL as shown below.

**In password recovery flow**
In password recovery flow, we send query params only once as given below.

`
https://localhost:9443/accountrecoveryendpoint/confirmrecovery.do?confirmation=315d3fca-316e-4a53-8c88-113db04bd459&userstoredomain=PRIMARY&username=user1&tenantdomain=xyz.com&callback=https%3A%2F%2Flocalhost%3A9443%2Fauthenticationendpoint%2Flogin.do%3Fclient_id%3DMY_ACCOUNT%26code_challenge%3DaECCL_okHo5Qwp52lbhiHLP8bBl0oW2B9mf4Thwt8qk%26code_challenge_method%3DS256%26commonAuthCallerPath%3D%2Foauth2%2Fauthorize%26forceAuth%3Dfalse%26passiveAuth%3Dfalse%26redirect_uri%3Dhttps%3A%2F%2Flocalhost%3A9443%2Fmyaccount%2Flogin%26response_mode%3Dform_post%26response_type%3Dcode%26scope%3DSYSTEM+openid%26tenantDomain%3Dcarbon.super%26sessionDataKey%3D097d46a0-6c0a-4e19-8260-10b3c58b017f%26relyingParty%3DMY_ACCOUNT%26type%3Doidc%26sp%3DMy+Account%26isSaaSApp%3Dtrue%26authenticators%3DBasicAuthenticator%3ALOCAL`
## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.