### PR TITLE
Remove captcha parameters from the authentication URL

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -751,14 +751,6 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                     }
                 }
 
-                // Add captcha configs
-                if (!captchaParams.isEmpty()) {
-                    captchaParams += BasicAuthenticatorConstants.RECAPTCHA_KEY_PARAM + captchaConfigs.getProperty
-                            (CaptchaConstants.RE_CAPTCHA_SITE_KEY) +
-                            BasicAuthenticatorConstants.RECAPTCHA_API_PARAM + captchaConfigs.getProperty
-                            (CaptchaConstants.RE_CAPTCHA_API_URL);
-                }
-
             } catch (IdentityGovernanceException e) {
                 log.error("Error occurred while verifying the captcha configs. Proceeding the authentication request " +
                         "without enabling recaptcha.", e);

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
@@ -1016,9 +1016,7 @@ public class BasicAuthenticatorTestCase {
                 BasicAuthenticatorConstants.AUTH_FAILURE_PARAM + "true" +
                 BasicAuthenticatorConstants.AUTH_FAILURE_MSG_PARAM + "user.tenant.domain.mismatch.message";
 
-        String captchaParams = BasicAuthenticatorConstants.RECAPTCHA_PARAM + "true" +
-                BasicAuthenticatorConstants.RECAPTCHA_KEY_PARAM + "dummySiteKey" +
-                BasicAuthenticatorConstants.RECAPTCHA_API_PARAM + "dummyApiUrl";
+        String captchaParams = BasicAuthenticatorConstants.RECAPTCHA_PARAM + "true";
 
         return new String[][]{
                 {"true", "dummySiteKey", "dummyApiUrl", "dummySecret", "dummyUrl", basicUrl + captchaParams},


### PR DESCRIPTION
Remove `recaptchaKey` and `recaptchaAPI` parameters from the authentication endpoint URL.