### PR TITLE
Check if user credentials are sent as query parameters

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -78,8 +78,6 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.PASSWORD;
-import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.USERNAME;
 
 /**
  * Username Password based Authenticator.
@@ -116,9 +114,8 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                                            HttpServletResponse response, AuthenticationContext context)
             throws AuthenticationFailedException, LogoutFailedException {
 
-        if (isURLContainSensitiveData(request)) {
-            throw new AuthenticationFailedException("Request URL contains user credentials. Cannot send user " +
-                    "credentials as query parameters with the URL");
+        if (isURLContainSensitiveData(request, response, context)) {
+           return AuthenticatorFlowStatus.INCOMPLETE;
         }
         Cookie autoLoginCookie = AutoLoginUtilities.getAutoLoginCookie(request.getCookies());
 
@@ -938,9 +935,31 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
         return MultitenantUtils.getTenantDomain(username);
     }
 
-    private boolean isURLContainSensitiveData(HttpServletRequest request) {
+    private boolean isURLContainSensitiveData(HttpServletRequest request, HttpServletResponse response,
+                                              AuthenticationContext context) throws AuthenticationFailedException {
 
-        return (StringUtils.contains(request.getQueryString(), USERNAME) &&
-                StringUtils.contains(request.getQueryString(), PASSWORD));
+        if (StringUtils.contains(request.getQueryString(), BasicAuthenticatorConstants.USER_NAME) &&
+                StringUtils.contains(request.getQueryString(), BasicAuthenticatorConstants.PASSWORD)) {
+
+            String loginPage = ConfigurationFacade.getInstance().getAuthenticationEndpointURL();
+            String queryParams = context.getContextIdIncludedQueryParams();
+            String redirectURL;
+            String retryParam = "";
+            retryParam = BasicAuthenticatorConstants.AUTH_FAILURE_PARAM + "true" +
+                    BasicAuthenticatorConstants.AUTH_FAILURE_MSG_PARAM + "query.params.contains.user.credentials";
+            redirectURL = loginPage + ("?" + queryParams)
+                    + BasicAuthenticatorConstants.AUTHENTICATORS + getName() + ":" +
+                    BasicAuthenticatorConstants.LOCAL + retryParam;
+            try {
+                response.sendRedirect(redirectURL);
+            } catch (IOException e) {
+                throw new AuthenticationFailedException(ErrorMessages.SYSTEM_ERROR_WHILE_AUTHENTICATING.getCode(),
+                        e.getMessage(),
+                        User.getUserFromUserName(request.getParameter(BasicAuthenticatorConstants.USER_NAME)), e);
+            }
+            return true;
+        }
+        return false;
     }
+
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -938,7 +938,7 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
     private boolean isURLContainSensitiveData(HttpServletRequest request, HttpServletResponse response,
                                               AuthenticationContext context) throws AuthenticationFailedException {
 
-        if (StringUtils.contains(request.getQueryString(), BasicAuthenticatorConstants.USER_NAME) &&
+        if (StringUtils.contains(request.getQueryString(), BasicAuthenticatorConstants.USER_NAME) ||
                 StringUtils.contains(request.getQueryString(), BasicAuthenticatorConstants.PASSWORD)) {
 
             String loginPage = ConfigurationFacade.getInstance().getAuthenticationEndpointURL();

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -78,6 +78,9 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.PASSWORD;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.USERNAME;
+
 /**
  * Username Password based Authenticator.
  */
@@ -113,6 +116,10 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                                            HttpServletResponse response, AuthenticationContext context)
             throws AuthenticationFailedException, LogoutFailedException {
 
+        if (isURLContainSensitiveData(request)) {
+            throw new AuthenticationFailedException("Request URL contains user credentials. Cannot send user " +
+                    "credentials as query parameters with the URL");
+        }
         Cookie autoLoginCookie = AutoLoginUtilities.getAutoLoginCookie(request.getCookies());
 
         if (context.isLogoutRequest()) {
@@ -929,5 +936,11 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
             return IdentityTenantUtil.getTenantDomainFromContext();
         }
         return MultitenantUtils.getTenantDomain(username);
+    }
+
+    private boolean isURLContainSensitiveData(HttpServletRequest request) {
+
+        return (StringUtils.contains(request.getQueryString(), USERNAME) &&
+                StringUtils.contains(request.getQueryString(), PASSWORD));
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -943,13 +943,10 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
 
             String loginPage = ConfigurationFacade.getInstance().getAuthenticationEndpointURL();
             String queryParams = context.getContextIdIncludedQueryParams();
-            String redirectURL;
-            String retryParam = "";
-            retryParam = BasicAuthenticatorConstants.AUTH_FAILURE_PARAM + "true" +
+            String redirectURL = loginPage + "?" + queryParams + BasicAuthenticatorConstants.AUTHENTICATORS +
+                    getName() + ":" + BasicAuthenticatorConstants.LOCAL +
+                    BasicAuthenticatorConstants.AUTH_FAILURE_PARAM + "true" +
                     BasicAuthenticatorConstants.AUTH_FAILURE_MSG_PARAM + "query.params.contains.user.credentials";
-            redirectURL = loginPage + ("?" + queryParams)
-                    + BasicAuthenticatorConstants.AUTHENTICATORS + getName() + ":" +
-                    BasicAuthenticatorConstants.LOCAL + retryParam;
             try {
                 response.sendRedirect(redirectURL);
             } catch (IOException e) {


### PR DESCRIPTION
## Purpose
* $subject
* Prevent authenticating users via GET requests. When sending GET requests, client credentials have to be sent as query parameters.

## Approach
Check the request URL contains user credentials.

## Related PR(s)
*  https://github.com/wso2/identity-apps/pull/2971

** Notes
Please merge [identity apps PR]( https://github.com/wso2/identity-apps/pull/2971) after merging this PR