### PR TITLE
Handle Pending User Information for Analytics

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/pom.xml
@@ -81,6 +81,10 @@
             <artifactId>json-simple</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -166,6 +170,8 @@
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.user.core.*; version="${carbon.kernel.imp.pkg.version.range}",
                             org.wso2.securevault.*; version="${org.wso2.securevault.import.version.range}",
+                            org.wso2.carbon.identity.configuration.mgt.core.*; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.context.*; version="${carbon.kernel.imp.pkg.version.range}"
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.application.authenticator.basicauth.internal,

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -84,6 +84,7 @@ import static org.wso2.carbon.identity.application.authenticator.basicauth.Basic
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.RESOURCE_TYPE_NAME_CONFIG;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.SHOW_PENDING_USER_INFORMATION_CONFIG;
+import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.SHOW_PENDING_USER_INFORMATION_DEFAULT_VALUE;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_ATTRIBUTE_DOES_NOT_EXISTS;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
@@ -1025,6 +1026,11 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
 
     private boolean showPendingUserInformationDefaultConfig() {
 
-        return Boolean.parseBoolean(IdentityUtil.getProperty(SHOW_PENDING_USER_INFORMATION_CONFIG));
+        String showPendingUserInformation = IdentityUtil.getProperty(SHOW_PENDING_USER_INFORMATION_CONFIG);
+        if (showPendingUserInformation == null) {
+            return SHOW_PENDING_USER_INFORMATION_DEFAULT_VALUE;
+        } else {
+            return Boolean.parseBoolean(showPendingUserInformation);
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.simple.JSONObject;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.authentication.framework.AbstractApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorFlowStatus;
 import org.wso2.carbon.identity.application.authentication.framework.LocalApplicationAuthenticator;
@@ -45,6 +46,7 @@ import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.captcha.connector.recaptcha.SSOLoginReCaptchaConfig;
 import org.wso2.carbon.identity.captcha.util.CaptchaConstants;
+import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.model.IdentityErrorMsgContext;
@@ -78,6 +80,14 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.RESOURCE_NAME_CONFIG;
+import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.RESOURCE_TYPE_NAME_CONFIG;
+import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG;
+import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.SHOW_PENDING_USER_INFORMATION_CONFIG;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_ATTRIBUTE_DOES_NOT_EXISTS;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_FEATURE_NOT_ENABLED;
 
 /**
  * Username Password based Authenticator.
@@ -591,9 +601,63 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                         ((UserStoreClientException) rootCause).getErrorCode() + ":" + rootCause.getMessage());
                 IdentityUtil.setIdentityErrorMsg(customErrorMessageContext);
             }
-            throw new AuthenticationFailedException(
-                    ErrorMessages.USER_STORE_EXCEPTION_WHILE_TRYING_TO_AUTHENTICATE.getCode(), e.getMessage(),
-                    User.getUserFromUserName(username), e);
+
+            boolean showPendingUserInfo = showPendingUserInformationDefaultConfig();
+            try {
+                PrivilegedCarbonContext.startTenantFlow();
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(IdentityTenantUtil.getTenantId
+                        (requestTenantDomain));
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(requestTenantDomain);
+                String tenantWiseConfig = BasicAuthenticatorDataHolder.getInstance()
+                        .getConfigurationManager().getAttribute(RESOURCE_TYPE_NAME_CONFIG, RESOURCE_NAME_CONFIG,
+                                PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG).getValue();
+                if (StringUtils.isNotBlank(tenantWiseConfig)) {
+                    showPendingUserInfo = Boolean.parseBoolean(tenantWiseConfig);
+                }
+            } catch (ConfigurationManagementException configException) {
+                if (ERROR_CODE_FEATURE_NOT_ENABLED.getCode().equals(configException.getErrorCode())) {
+                    if (log.isDebugEnabled()) {
+                        log.debug(String.format("%s Therefore using the default configuration value: %s for the " +
+                                "attribute: %s", ERROR_CODE_FEATURE_NOT_ENABLED.getMessage(), showPendingUserInfo,
+                                PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG));
+                    }
+                } else if (ERROR_CODE_ATTRIBUTE_DOES_NOT_EXISTS.getCode().equals(configException.getErrorCode())) {
+                    if (log.isDebugEnabled()) {
+                        log.debug(String.format("%s attribute doesn't exist for the tenant: %s. Therefore using the " +
+                                "default configuration value: %s for the attribute: %s",
+                                PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG, requestTenantDomain,
+                                showPendingUserInfo, PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG));
+                    }
+                } else if (ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS.getCode().equals(configException.getErrorCode())) {
+                    if (log.isDebugEnabled()) {
+                        log.debug(String.format("%s resource type doesn't exist for the tenant: %s. Therefore using " +
+                                "the default configuration value: %s for the attribute: %s",
+                                RESOURCE_TYPE_NAME_CONFIG, requestTenantDomain, showPendingUserInfo,
+                                PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG));
+                    }
+                } else if (ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode().equals(configException.getErrorCode())) {
+                    if (log.isDebugEnabled()) {
+                        log.debug(String.format("%s resource doesn't exist for the tenant: %s. Therefore using the " +
+                                "default configuration value: %s for the attribute: %s", RESOURCE_NAME_CONFIG,
+                                requestTenantDomain, showPendingUserInfo,
+                                PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG));
+                    }
+                } else {
+                    throw new AuthenticationFailedException(String.format("Error in retrieving %s configuration for " +
+                            "the tenant %s", PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG, requestTenantDomain, e));
+                }
+            } finally {
+                PrivilegedCarbonContext.endTenantFlow();
+            }
+            if (showPendingUserInfo) {
+                throw new AuthenticationFailedException(
+                        ErrorMessages.USER_STORE_EXCEPTION_WHILE_TRYING_TO_AUTHENTICATE.getCode(), e.getMessage(),
+                        User.getUserFromUserName(username), e);
+            } else {
+                throw new AuthenticationFailedException(
+                        ErrorMessages.USER_STORE_EXCEPTION_WHILE_TRYING_TO_AUTHENTICATE.getCode(), e.getMessage(),
+                        e);
+            }
         } finally {
             clearUserExistThreadLocal();
         }
@@ -959,4 +1023,8 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
         return false;
     }
 
+    private boolean showPendingUserInformationDefaultConfig() {
+
+        return Boolean.parseBoolean(IdentityUtil.getProperty(SHOW_PENDING_USER_INFORMATION_CONFIG));
+    }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
@@ -53,6 +53,11 @@ public abstract class BasicAuthenticatorConstants {
 
     public static final String AUTHENTICATION_POLICY_CONFIG = "AuthenticationPolicy.CheckAccountExist";
 
+    public static final String RESOURCE_TYPE_NAME_CONFIG = "basic-authenticator-config";
+    public static final String RESOURCE_NAME_CONFIG = "user-information";
+    public static final String PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG = "ShowPendingUserInformation.enable";
+    public static final String SHOW_PENDING_USER_INFORMATION_CONFIG = "ShowPendingUserInformation";
+
     private BasicAuthenticatorConstants() {
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
@@ -57,6 +57,7 @@ public abstract class BasicAuthenticatorConstants {
     public static final String RESOURCE_NAME_CONFIG = "user-information";
     public static final String PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG = "ShowPendingUserInformation.enable";
     public static final String SHOW_PENDING_USER_INFORMATION_CONFIG = "ShowPendingUserInformation";
+    public static final boolean SHOW_PENDING_USER_INFORMATION_DEFAULT_VALUE = true;
 
     private BasicAuthenticatorConstants() {
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorDataHolder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorDataHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.application.authenticator.basicauth.internal;
 
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 
@@ -31,10 +32,9 @@ public class BasicAuthenticatorDataHolder {
     private static BasicAuthenticatorDataHolder instance = new BasicAuthenticatorDataHolder();
 
     private IdentityGovernanceService identityGovernanceService;
-
     private MultiAttributeLoginService multiAttributeLogin;
-
     private Properties recaptchaConfigs;
+    private ConfigurationManager configurationManager = null;
 
     private BasicAuthenticatorDataHolder() {
 
@@ -68,5 +68,15 @@ public class BasicAuthenticatorDataHolder {
 
     public void setRecaptchaConfigs(Properties recaptchaConfigs) {
         this.recaptchaConfigs = recaptchaConfigs;
+    }
+
+    public void setConfigurationManager(ConfigurationManager configurationManager) {
+
+        this.configurationManager = configurationManager;
+    }
+
+    public ConfigurationManager getConfigurationManager() {
+
+        return configurationManager;
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorServiceComponent.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorServiceComponent.java
@@ -29,6 +29,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticator;
 import org.wso2.carbon.identity.captcha.util.CaptchaConstants;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
@@ -132,6 +133,29 @@ public class BasicAuthenticatorServiceComponent {
     protected void unsetMultiAttributeLoginService(MultiAttributeLoginService multiAttributeLogin) {
 
         BasicAuthenticatorDataHolder.getInstance().setMultiAttributeLogin(null);
+    }
+
+    @Reference(
+            name = "resource.configuration.manager",
+            service = ConfigurationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unregisterConfigurationManager"
+    )
+    protected void registerConfigurationManager(ConfigurationManager configurationManager) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting the configuration manager in basic authenticator bundle.");
+        }
+        BasicAuthenticatorDataHolder.getInstance().setConfigurationManager(configurationManager);
+    }
+
+    protected void unregisterConfigurationManager(ConfigurationManager configurationManager) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Unsetting the configuration manager in basic authenticator bundle.");
+        }
+        BasicAuthenticatorDataHolder.getInstance().setConfigurationManager(null);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
@@ -52,6 +52,9 @@ import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
 import org.wso2.carbon.identity.captcha.util.CaptchaConstants;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
+import org.wso2.carbon.identity.configuration.mgt.core.exception.ConfigurationManagementException;
+import org.wso2.carbon.identity.configuration.mgt.core.model.Attribute;
 import org.wso2.carbon.identity.core.internal.IdentityCoreServiceComponent;
 import org.wso2.carbon.identity.core.model.IdentityErrorMsgContext;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
@@ -109,7 +112,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG;
+import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.RESOURCE_NAME_CONFIG;
+import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.RESOURCE_TYPE_NAME_CONFIG;
+import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.SHOW_PENDING_USER_INFORMATION_CONFIG;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.util.AutoLoginConstant.CONTENT;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.util.AutoLoginConstant.COOKIE_NAME;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.util.AutoLoginConstant.CREATED_TIME;
@@ -123,6 +131,10 @@ import static org.wso2.carbon.identity.application.authenticator.basicauth.util.
 import static org.wso2.carbon.identity.application.authenticator.basicauth.util.AutoLoginConstant.SIGNATURE;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.util.AutoLoginConstant.SIGNUP;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.util.AutoLoginConstant.USERNAME;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_ATTRIBUTE_DOES_NOT_EXISTS;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_FEATURE_NOT_ENABLED;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS;
 
 /**
  * Unit test cases for the Basic Authenticator.
@@ -866,6 +878,108 @@ public class BasicAuthenticatorTestCase {
             }
         }
     }
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    @DataProvider(name = "pendingUserInformationDetailsProvider")
+    public Object[][] pendingUserInformationDetailsProvider() {
+
+        return new Object[][] {
+                {true, ""},
+                {true, ERROR_CODE_FEATURE_NOT_ENABLED.getCode()},
+                {true, ERROR_CODE_ATTRIBUTE_DOES_NOT_EXISTS.getCode()},
+                {true, ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS.getCode()},
+                {true, ERROR_CODE_RESOURCE_DOES_NOT_EXISTS.getCode()},
+                {false, ""}
+        };
+    }
+
+    @Test(dataProvider = "pendingUserInformationDetailsProvider")
+    public void processAuthenticationResponseTestCaseForUserStoreExceptionWithPendingUserInformation(
+            boolean showPendingUserInfo, String configManagementErrorCode) throws Exception {
+
+        try (MockedStatic<MultitenantUtils> multitenantUtils = Mockito.mockStatic(MultitenantUtils.class);
+             MockedStatic<FrameworkUtils> frameworkUtils = Mockito.mockStatic(FrameworkUtils.class);
+             MockedStatic<IdentityTenantUtil> identityTenantUtil = Mockito.mockStatic(IdentityTenantUtil.class);
+             MockedStatic<User> user = Mockito.mockStatic(User.class);
+             MockedStatic<IdentityUtil> identityUtil = Mockito.mockStatic(IdentityUtil.class);
+             MockedStatic<PrivilegedCarbonContext> privilegedCarbonContext = Mockito.mockStatic(
+                     PrivilegedCarbonContext.class);
+             MockedStatic<BasicAuthenticatorServiceComponent> basicAuthenticatorService =
+                     Mockito.mockStatic(BasicAuthenticatorServiceComponent.class)) {
+
+            when(mockAuthnCtxt.getProperties()).thenReturn(new HashMap<>());
+            when(mockAuthnCtxt.getAuthenticatorParams("common")).thenReturn(null);
+
+            when(mockRequest.getParameter(BasicAuthenticatorConstants.USER_NAME)).thenReturn(DUMMY_USER_NAME);
+            when(mockRequest.getParameter(BasicAuthenticatorConstants.PASSWORD)).thenReturn(DUMMY_PASSWORD);
+
+            identityTenantUtil.when(() -> IdentityTenantUtil.getTenantIdOfUser(DUMMY_USER_NAME))
+                    .thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+
+            basicAuthenticatorService.when(BasicAuthenticatorServiceComponent::getRealmService)
+                    .thenReturn(mockRealmService);
+            mockRealm = mock(UserRealm.class);
+            when(mockRealmService.getTenantUserRealm(MultitenantConstants.SUPER_TENANT_ID))
+                    .thenReturn((UserRealm) mockRealm);
+            when(mockRealmService.getTenantManager()).thenReturn(mockTenantManager);
+            when(mockTenantManager.getTenantId(anyString())).thenReturn(MultitenantConstants.SUPER_TENANT_ID);
+            when(((UserRealm) mockRealm).getUserStoreManager()).thenReturn(mockUserStoreManager);
+
+            multitenantUtils.when(() -> MultitenantUtils.getTenantAwareUsername(DUMMY_USER_NAME))
+                    .thenReturn(DUMMY_USER_NAME);
+            multitenantUtils.when(() -> MultitenantUtils.getTenantDomain(DUMMY_USER_NAME))
+                    .thenReturn(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+
+            Map<String, Object> mockedThreadLocalMap = new HashMap<>();
+            mockedThreadLocalMap.put("user-domain-recaptcha", "someDomain");
+            IdentityUtil.threadLocalProperties.set(mockedThreadLocalMap);
+
+            frameworkUtils.when(() -> FrameworkUtils.preprocessUsername(DUMMY_USER_NAME, mockAuthnCtxt))
+                    .thenReturn(DUMMY_USER_NAME);
+            when(mockUserStoreManager.authenticateWithID(UserCoreClaimConstants.USERNAME_CLAIM_URI,
+                    MultitenantUtils.getTenantAwareUsername(DUMMY_USER_NAME), DUMMY_PASSWORD,
+                    UserCoreConstants.DEFAULT_PROFILE)).thenThrow(new org.wso2.carbon.user.core.UserStoreException());
+
+//            when(IdentityUtil.getProperty(SHOW_PENDING_USER_INFORMATION_CONFIG)).thenReturn("false");
+
+            identityUtil.when(() -> IdentityUtil.getProperty(SHOW_PENDING_USER_INFORMATION_CONFIG))
+                    .thenReturn("false");
+
+            User userFromUsername = new User();
+            userFromUsername.setUserName(DUMMY_USER_NAME);
+            user.when(() -> User.getUserFromUserName(anyString())).thenReturn(userFromUsername);
+
+            privilegedCarbonContext.when(PrivilegedCarbonContext::getThreadLocalCarbonContext)
+                    .thenReturn(mockPrivilegedCarbonContext);
+            Attribute pendingUserAttribute = new Attribute(PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG,
+                    String.valueOf(showPendingUserInfo));
+            ConfigurationManager configurationManager = mock(ConfigurationManager.class);
+            if (StringUtils.isEmpty(configManagementErrorCode)) {
+                when(configurationManager.getAttribute(RESOURCE_TYPE_NAME_CONFIG, RESOURCE_NAME_CONFIG,
+                        PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG)).thenReturn(pendingUserAttribute);
+            } else {
+                when(configurationManager.getAttribute(RESOURCE_TYPE_NAME_CONFIG, RESOURCE_NAME_CONFIG,
+                        PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG)).thenThrow(
+                        new ConfigurationManagementException("", configManagementErrorCode));
+            }
+            BasicAuthenticatorDataHolder.getInstance().setConfigurationManager(configurationManager);
+
+            try {
+                basicAuthenticator.processAuthenticationResponse(mockRequest, mockResponse, mockAuthnCtxt);
+            } catch (AuthenticationFailedException ex) {
+                assertNotNull(ex);
+                if (StringUtils.isNotEmpty(configManagementErrorCode)) {
+                    assertNull(ex.getUser());
+                } else if (showPendingUserInfo) {
+                    assertEquals(ex.getUser(), userFromUsername);
+                } else {
+                    assertNull(ex.getUser());
+                }
+            }
+        }
+    }
+    ///////////////////////////////////////////////////////////////////////////////////////////////
 
 
     @DataProvider(name = "enableStatusProvider")

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
@@ -879,8 +879,6 @@ public class BasicAuthenticatorTestCase {
         }
     }
 
-
-    ///////////////////////////////////////////////////////////////////////////////////////////////
     @DataProvider(name = "pendingUserInformationDetailsProvider")
     public Object[][] pendingUserInformationDetailsProvider() {
 
@@ -941,8 +939,6 @@ public class BasicAuthenticatorTestCase {
                     MultitenantUtils.getTenantAwareUsername(DUMMY_USER_NAME), DUMMY_PASSWORD,
                     UserCoreConstants.DEFAULT_PROFILE)).thenThrow(new org.wso2.carbon.user.core.UserStoreException());
 
-//            when(IdentityUtil.getProperty(SHOW_PENDING_USER_INFORMATION_CONFIG)).thenReturn("false");
-
             identityUtil.when(() -> IdentityUtil.getProperty(SHOW_PENDING_USER_INFORMATION_CONFIG))
                     .thenReturn("false");
 
@@ -979,8 +975,6 @@ public class BasicAuthenticatorTestCase {
             }
         }
     }
-    ///////////////////////////////////////////////////////////////////////////////////////////////
-
 
     @DataProvider(name = "enableStatusProvider")
     public Object[][] getEnabledOption() {

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorServiceComponentTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorServiceComponentTestCase.java
@@ -21,6 +21,7 @@ import org.mockito.Mockito;
 import org.osgi.service.component.ComponentContext;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.user.core.service.RealmService;
 
 import static org.mockito.Mockito.mock;
@@ -32,6 +33,7 @@ public class BasicAuthenticatorServiceComponentTestCase {
     private RealmService mockRealmService;
     private BasicAuthenticatorServiceComponent basicAuthenticatorServiceComponent;
     private ComponentContext mockComponentContext;
+    private ConfigurationManager mockConfigManager;
 
     @BeforeMethod
     public void init() {
@@ -67,5 +69,21 @@ public class BasicAuthenticatorServiceComponentTestCase {
         basicAuthenticatorServiceComponent.activate(componentContext);
 
         Mockito.verify(componentContext, Mockito.atLeastOnce()).getBundleContext();
+    }
+
+    @Test
+    public void registerConfigurationManager() {
+
+        mockConfigManager = mock(ConfigurationManager.class);
+        basicAuthenticatorServiceComponent.registerConfigurationManager(mockConfigManager);
+        assertNotNull(BasicAuthenticatorDataHolder.getInstance().getConfigurationManager());
+    }
+
+    @Test
+    public void unregisterConfigurationManager() {
+
+        mockConfigManager = mock(ConfigurationManager.class);
+        basicAuthenticatorServiceComponent.unregisterConfigurationManager(mockConfigManager);
+        assertNull(BasicAuthenticatorDataHolder.getInstance().getConfigurationManager());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,11 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jacoco</groupId>
                 <artifactId>org.jacoco.agent</artifactId>
                 <classifier>runtime</classifier>


### PR DESCRIPTION
**Description**
With the fix, pending user information will be sent to analytics  only if we enable a configuration. Configuration is available system wise as well as tenant wise. **Default value for the config will be true.**

System wise configuration should be disabled in the deployment.toml config as below.
[show_pending_user_information]
enabled = false

Tenant wise configuration should be disabled/ enabled through configuration management feature.
1. Create a resource type as below
```
curl --location --request POST 'https://localhost:9443/api/identity/config-mgt/v1.0/resource-type' \
--header 'accept: application/json' \
--header 'Content-Type: application/json' \
--header 'Authorization: Basic YWRtaW46YWRtaW4=' \
--data-raw '{"name": "basic-authenticator-config", "description": "This is the resource type for pending users."}'
```
2. Create resource as below.
```
curl --location --request POST 'https://localhost:9443/api/identity/config-mgt/v1.0/resource/basic-authenticator-config' \
--header 'accept: application/json' \
--header 'Content-Type: application/json' \
--header 'Authorization: Basic YWRtaW46YWRtaW4=' \
--data-raw '{"name": "user-information","attributes": [{"key": "ShowPendingUserInformation.enable","value": "true"}]}'
```

**Related issue**
- https://github.com/wso2/product-is/issues/13667

**Note**
For is-5.10, by default this will be disabled. However considering the fix done with [#8667](https://github.com/wso2/product-is/issues/8667), it is decided to keep this enabled as the default config.

**Related PR**
- https://github.com/wso2-support/identity-local-auth-basicauth/pull/114