### PR TITLE
Prompt for reCaptcha in SSO login flows based on the system wide config

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -759,6 +759,8 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
         if (captchaConfigs != null && !captchaConfigs.isEmpty() &&
                 Boolean.parseBoolean(captchaConfigs.getProperty(CaptchaConstants.RE_CAPTCHA_ENABLED))) {
 
+            boolean forcefullyEnabledRecaptchaForAllTenants = Boolean.parseBoolean(captchaConfigs.getProperty(
+                    CaptchaConstants.FORCEFULLY_ENABLED_RECAPTCHA_FOR_ALL_TENANTS));
             try {
                 connectorConfigs = BasicAuthenticatorDataHolder.getInstance().getIdentityGovernanceService()
                         .getConfiguration(new String[]{defaultCaptchaConfigName, RESEND_CONFIRMATION_RECAPTCHA_ENABLE,
@@ -766,7 +768,8 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                 for (Property connectorConfig : connectorConfigs) {
                     if (defaultCaptchaConfigName.equals(connectorConfig.getName())) {
                         // SSO Login Captcha Config
-                        if (Boolean.parseBoolean(connectorConfig.getValue())) {
+                        if (Boolean.parseBoolean(connectorConfig.getValue()) ||
+                                forcefullyEnabledRecaptchaForAllTenants) {
                             captchaParams = BasicAuthenticatorConstants.RECAPTCHA_PARAM + "true";
                         } else {
                             if (log.isDebugEnabled()) {
@@ -775,7 +778,8 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                         }
                     } else if ((RESEND_CONFIRMATION_RECAPTCHA_ENABLE).equals(connectorConfig.getName())) {
                         // Resend Confirmation Captcha Config
-                        if (Boolean.parseBoolean(connectorConfig.getValue())) {
+                        if (Boolean.parseBoolean(connectorConfig.getValue()) ||
+                                forcefullyEnabledRecaptchaForAllTenants) {
                             captchaParams += BasicAuthenticatorConstants.RECAPTCHA_RESEND_CONFIRMATION_PARAM + "true";
                         } else {
                             if (log.isDebugEnabled()) {

--- a/pom.xml
+++ b/pom.xml
@@ -345,8 +345,8 @@
         <carbon.identity.framework.imp.pkg.version.range>[5.19.14, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
-        <identity.governance.version>1.3.28</identity.governance.version>
-        <identity.governance.imp.pkg.version.range>[1.3.28, 2.0.0)</identity.governance.imp.pkg.version.range>
+        <identity.governance.version>1.5.89</identity.governance.version>
+        <identity.governance.imp.pkg.version.range>[1.5.89, 2.0.0)</identity.governance.imp.pkg.version.range>
 
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>


### PR DESCRIPTION
Resolves part of [product-is #13525](https://github.com/wso2/product-is/issues/13525)
Dependent on [identity-governance #598](https://github.com/wso2-extensions/identity-governance/pull/598)

This PR modifies the basic authenticator logic to prompt for reCaptcha based on the system wide configuration introduced by [identity-governance #598](https://github.com/wso2-extensions/identity-governance/pull/598). If the config is enabled, reCaptcha will be required in the SSO login flows of all tenants irrespective of the tenant wise reCaptcha configuration for SSO.