### PR TITLE
Add support to pass custom params to login page form basic authenticator in adaptive scripts

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -104,6 +104,7 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
     private static final String APPEND_USER_TENANT_TO_USERNAME = "appendUserTenantToUsername";
     private static final String RE_CAPTCHA_USER_DOMAIN = "user-domain-recaptcha";
     private List<String> omittingErrorParams = null;
+    public static final String ADDITIONAL_QUERY_PARAMS = "additionalParams";
 
     /**
      * USER_EXIST_THREAD_LOCAL_PROPERTY is used to maintain the state of user existence
@@ -256,6 +257,10 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
             if (FrameworkConstants.INPUT_TYPE_IDENTIFIER_FIRST.equalsIgnoreCase(inputType)) {
                 queryParams += "&" + FrameworkConstants.RequestParams.INPUT_TYPE + "=" + inputType;
                 context.addEndpointParam(FrameworkConstants.JSAttributes.JS_OPTIONS_USERNAME, usernameFromContext);
+            }
+            String additionalParams = runtimeParams.get(ADDITIONAL_QUERY_PARAMS);
+            if (StringUtils.isNotBlank(additionalParams)) {
+                queryParams += "&" + additionalParams;
             }
         }
 


### PR DESCRIPTION
A sample
```
executeStep(2, {
    stepOptions: {
        forceAuth: 'true'
    },
    authenticatorParams: {
        common: {
            'username': context.currentKnownSubject.username + '@carbon.super',
            'appendUserTenantToUsername': "true",
            'additionalParams': 'theme=guardio-life&action=link'
        }
    }
}, {
    onSuccess: function(context) {
      
    }
});
```
`additionalParams` will be passed to the basic auth login page.