### PR TITLE
Use the original query string when the request is an instance of AuthenticationFrameworkWrapper

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -34,6 +34,7 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.A
 import org.wso2.carbon.identity.application.authentication.framework.exception.InvalidCredentialsException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.LogoutFailedException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticationFrameworkWrapper;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.basicauth.internal.BasicAuthenticatorDataHolder;
@@ -1025,8 +1026,16 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
     private boolean isURLContainSensitiveData(HttpServletRequest request, HttpServletResponse response,
                                               AuthenticationContext context) throws AuthenticationFailedException {
 
-        if (StringUtils.contains(request.getQueryString(), BasicAuthenticatorConstants.USER_NAME) ||
-                StringUtils.contains(request.getQueryString(), BasicAuthenticatorConstants.PASSWORD)) {
+        String queryString;
+        if (request instanceof AuthenticationFrameworkWrapper) {
+            queryString = ((HttpServletRequest) ((AuthenticationFrameworkWrapper) request).getRequest())
+                    .getQueryString();
+        } else {
+            queryString = request.getQueryString();
+        }
+
+        if (StringUtils.contains(queryString, BasicAuthenticatorConstants.USER_NAME + "=") ||
+                StringUtils.contains(queryString, BasicAuthenticatorConstants.PASSWORD + "=")) {
 
             String loginPage = ConfigurationFacade.getInstance().getAuthenticationEndpointURL();
             String queryParams = context.getContextIdIncludedQueryParams();


### PR DESCRIPTION
## Purpose
* Use the original query string when the request is an instance of AuthenticationFrameworkWrapper to get the query string with only the url params.
* Add "=" to the search key to not to consider the values of the query string.

## Related issues
* https://github.com/wso2-enterprise/wso2-iam-internal/issues/223