### PR TITLE
Introduce new config to add application tenant domain to username for SaaS applications

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -103,6 +103,7 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
     private static final Log log = LogFactory.getLog(BasicAuthenticator.class);
     private static final String RESEND_CONFIRMATION_RECAPTCHA_ENABLE = "SelfRegistration.ResendConfirmationReCaptcha";
     private static final String APPEND_USER_TENANT_TO_USERNAME = "appendUserTenantToUsername";
+    private static final String APPEND_APP_TENANT_TO_USERNAME = "appendAppTenantToUsername";
     private static final String RE_CAPTCHA_USER_DOMAIN = "user-domain-recaptcha";
     public static final String ADDITIONAL_QUERY_PARAMS = "additionalParams";
 
@@ -518,6 +519,16 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
             String appendUserTenant = runtimeParams.get(APPEND_USER_TENANT_TO_USERNAME);
             if (Boolean.parseBoolean(appendUserTenant)) {
                 loginIdentifierFromRequest = loginIdentifierFromRequest + "@" + context.getUserTenantDomain();
+            }
+
+            /** FrameworkUtils.preprocessUsername will not append the tenant domain to username, if you are using
+             * email as username and EnableEmailUserName config is not enabled. So for a SaaS app, this config needs
+             * to be enabled to add the tenant domain of the application to email username if EnableEmailUserName
+             * is not enabled in the system.
+             **/
+            String appendAppTenant = runtimeParams.get(APPEND_APP_TENANT_TO_USERNAME);
+            if (Boolean.parseBoolean(appendAppTenant)) {
+                loginIdentifierFromRequest = loginIdentifierFromRequest + "@" + context.getTenantDomain();
             }
         }
 


### PR DESCRIPTION
## Purpose
- Currently we have `appendUserTenantToUsername` config to add user tenant domain to the username when email as username is not enabled. We have a requirement to append application tenant domain to the username with a config as well. This PR is to cater that requirement. In this PR we are introducing the `appendAppTenantToUsername` flag to append application tenant domain to email username.