### PR TITLE
Get user sessions with user Id and tenant domain

### DIFF
--- a/components/org.wso2.carbon.identity.application.authentication.handler.session/src/main/java/org/wso2/carbon/identity/application/authentication/handler/session/ActiveSessionsLimitHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.session/src/main/java/org/wso2/carbon/identity/application/authentication/handler/session/ActiveSessionsLimitHandler.java
@@ -116,7 +116,7 @@ public class ActiveSessionsLimitHandler extends AbstractApplicationAuthenticator
 
                 List<UserSession> userSessions = null;
                 if (userId != null) {
-                    userSessions = getUserSessions(userId);
+                    userSessions = getUserSessions(userId, context.getTenantDomain());
                 }
 
                 StepConfig stepConfig = getCurrentSubjectIdentifierStep(context);
@@ -174,7 +174,7 @@ public class ActiveSessionsLimitHandler extends AbstractApplicationAuthenticator
                         = request.getParameterValues(ActiveSessionsLimitHandlerConstants.SESSIONS_TO_TERMINATE);
                 terminateSessions(userId, sessionIdsToTerminate);
                 maxSessionCount = Integer.parseInt(maxSessionCountParamValue);
-                userSessions = getUserSessions(userId);
+                userSessions = getUserSessions(userId, context.getTenantDomain());
                 if (userSessions != null && userSessions.size() >= maxSessionCount) {
                     prepareEndpointParams(context, maxSessionCountParamValue, userSessions);
                     throw new AuthenticationFailedException("Active session count: " + userSessions.size()
@@ -228,14 +228,13 @@ public class ActiveSessionsLimitHandler extends AbstractApplicationAuthenticator
                 .collect(Collectors.toList());
     }
 
-    private List<UserSession> getUserSessions(String userId)
-            throws UserSessionRetrievalException {
+    private List<UserSession> getUserSessions(String userId, String tenantDomain) throws UserSessionRetrievalException {
 
         List<UserSession> userSessions;
 
         try {
             userSessions = ActiveSessionsLimitHandlerServiceHolder.getInstance()
-                    .getUserSessionManagementService().getSessionsByUserId(userId);
+                    .getUserSessionManagementService().getSessionsByUserId(userId, tenantDomain);
             if (log.isDebugEnabled()) {
                 log.debug("Retrieved " + userSessions.size() + " for userId: " + userId);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.25.87</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.90</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.19.14, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.25.71</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.87</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.19.14, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-is/issues/15223
Merge after - https://github.com/wso2/carbon-identity-framework/pull/4412

## Approach
As of now, the tenant domain is retrieved from the PRivileged Carbon Context in the framework side. But this leads to [1], where super tenant domain is retrieved in tenanted sessions. Hence, we are passing the tenant domain from the context to the framework method introduced with [2]

[1] - https://github.com/wso2/product-is/issues/15223
[2] - https://github.com/wso2/carbon-identity-framework/pull/4412

## Related PRs
> [Overload getSessionByUserId to pass the tenant domain](https://github.com/wso2/carbon-identity-framework/pull/4412)
