### PR TITLE
Set user entered username to context so that data publisher can use that value to publish data

### DIFF
--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
@@ -71,6 +71,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.IDENTIFIER_CONSENT;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.RESTART_FLOW;
+import static org.wso2.carbon.identity.application.authentication.handler.identifier.IdentifierHandlerConstants.IS_INVALID_USERNAME;
+import static org.wso2.carbon.identity.application.authentication.handler.identifier.IdentifierHandlerConstants.USERNAME_USER_INPUT;
 
 /**
  * Identifier based handler.
@@ -364,6 +366,7 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
             throw new InvalidCredentialsException(ErrorMessages.EMPTY_USERNAME.getCode(),
                     ErrorMessages.EMPTY_USERNAME.getMessage());
         }
+        context.setProperty(USERNAME_USER_INPUT, identifierFromRequest);
         if (runtimeParams != null) {
             String skipPreProcessUsername = runtimeParams.get(SKIP_IDENTIFIER_PRE_PROCESS);
             if (Boolean.parseBoolean(skipPreProcessUsername)) {
@@ -395,6 +398,7 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
                         context.getTenantDomain());
                 userId = resolvedUserResult.getUser().getUserID();
             } else {
+                context.setProperty(IS_INVALID_USERNAME, true);
                 throw new InvalidCredentialsException(ErrorMessages.USER_DOES_NOT_EXISTS.getCode(),
                         ErrorMessages.USER_DOES_NOT_EXISTS.getMessage(), User.getUserFromUserName(username));
             }

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandlerConstants.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandlerConstants.java
@@ -31,6 +31,8 @@ public abstract class IdentifierHandlerConstants {
     public static final String AUTHENTICATORS = "&authenticators=";
     public static final String LOCAL = "LOCAL";
     public static final String UTF_8 = "UTF-8";
+    public static final String IS_INVALID_USERNAME = "isInvalidUsername";
+    public static final String USERNAME_USER_INPUT = "usernameUserInput";
 
     private IdentifierHandlerConstants() {
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -81,11 +81,13 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.IS_INVALID_USERNAME;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.RESOURCE_NAME_CONFIG;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.RESOURCE_TYPE_NAME_CONFIG;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.SHOW_PENDING_USER_INFORMATION_CONFIG;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.SHOW_PENDING_USER_INFORMATION_DEFAULT_VALUE;
+import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.USERNAME_USER_INPUT;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_ATTRIBUTE_DOES_NOT_EXISTS;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
@@ -510,6 +512,7 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
             throw new InvalidCredentialsException(ErrorMessages.EMPTY_USERNAME.getCode(),
                     ErrorMessages.EMPTY_USERNAME.getMessage());
         }
+        context.setProperty(USERNAME_USER_INPUT, loginIdentifierFromRequest);
         Map<String, String> runtimeParams = getRuntimeParams(context);
         if (runtimeParams != null) {
             // FrameworkUtils.preprocessUsername will not append the tenant domain to username, if you are using
@@ -550,6 +553,7 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                 username = UserCoreUtil.addTenantDomainToEntry(tenantAwareUsername, requestTenantDomain);
                 userId = resolvedUserResult.getUser().getUserID();
             } else {
+                context.setProperty(IS_INVALID_USERNAME, true);
                 throw new InvalidCredentialsException(ErrorMessages.USER_DOES_NOT_EXISTS.getCode(),
                         ErrorMessages.USER_DOES_NOT_EXISTS.getMessage(), User.getUserFromUserName(username));
             }

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
@@ -57,6 +57,8 @@ public abstract class BasicAuthenticatorConstants {
     public static final String RESOURCE_NAME_CONFIG = "user-information";
     public static final String PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG = "ShowPendingUserInformation.enable";
     public static final String SHOW_PENDING_USER_INFORMATION_CONFIG = "ShowPendingUserInformation";
+    public static final String IS_INVALID_USERNAME = "isInvalidUsername";
+    public static final String USERNAME_USER_INPUT = "usernameUserInput";
     public static final boolean SHOW_PENDING_USER_INFORMATION_DEFAULT_VALUE = true;
 
     private BasicAuthenticatorConstants() {


### PR DESCRIPTION
## Purpose
- In order to publish user entered value for analytic purposes, set the input value to context and pass.
- In the username is an invalid value (user does not exists in the system), update the context with a new parameter so that analytics can publish data based on that value

## Related Issues
- https://github.com/wso2/product-is/issues/15327