### PR TITLE
Add basicauth auth attribute handler

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/pom.xml
@@ -85,6 +85,10 @@
             <artifactId>org.wso2.carbon.identity.configuration.mgt.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.auth.attribute.handler</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -166,6 +170,7 @@
                             org.wso2.carbon.identity.recovery; version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.recovery.util; version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.governance.common; version="${identity.governance.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.auth.attribute.handler.*; version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.multi.attribute.login.mgt.*;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.user.core.*; version="${carbon.kernel.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/attribute/handler/BasicAuthAuthAttributeHandler.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/attribute/handler/BasicAuthAuthAttributeHandler.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authenticator.basicauth.attribute.handler;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants;
+import org.wso2.carbon.identity.auth.attribute.handler.AuthAttributeHandler;
+import org.wso2.carbon.identity.auth.attribute.handler.AuthAttributeHandlerBindingType;
+import org.wso2.carbon.identity.auth.attribute.handler.AuthAttributeHandlerConstants;
+import org.wso2.carbon.identity.auth.attribute.handler.model.AuthAttribute;
+import org.wso2.carbon.identity.auth.attribute.handler.model.AuthAttributeHolder;
+import org.wso2.carbon.identity.auth.attribute.handler.model.AuthAttributeType;
+import org.wso2.carbon.identity.auth.attribute.handler.model.ValidationFailureReason;
+import org.wso2.carbon.identity.auth.attribute.handler.model.ValidationResult;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.wso2.carbon.identity.auth.attribute.handler.AuthAttributeHandlerConstants.ErrorMessages.ERROR_CODE_ATTRIBUTE_NOT_FOUND;
+import static org.wso2.carbon.identity.auth.attribute.handler.AuthAttributeHandlerConstants.ErrorMessages.ERROR_CODE_ATTRIBUTE_VALUE_EMPTY;
+
+/**
+ * Auth attribute handler implementation for the BasicAuth authenticator.
+ */
+public class BasicAuthAuthAttributeHandler implements AuthAttributeHandler {
+
+    private static final String HANDLER_NAME = "BasicAuthAuthAttributeHandler";
+    private static final String ATTRIBUTE_USERNAME = "username";
+    private static final String ATTRIBUTE_PASSWORD = "password";
+
+    @Override
+    public String getName() {
+
+        return HANDLER_NAME;
+    }
+
+    @Override
+    public AuthAttributeHandlerBindingType getBindingType() {
+
+        return AuthAttributeHandlerBindingType.AUTHENTICATOR;
+    }
+
+    @Override
+    public String getBoundIdentifier() {
+
+        return BasicAuthenticatorConstants.AUTHENTICATOR_NAME;
+    }
+
+    @Override
+    public AuthAttributeHolder getAuthAttributeData() {
+
+        List<AuthAttribute> authAttributes = new ArrayList<>();
+        authAttributes.add(buildAuthAttribute(ATTRIBUTE_USERNAME, false));
+        authAttributes.add(buildAuthAttribute(ATTRIBUTE_PASSWORD, true));
+
+        return new AuthAttributeHolder(
+                getName(),
+                getBindingType(),
+                getBoundIdentifier(),
+                authAttributes
+        );
+    }
+
+    @Override
+    public ValidationResult validateAttributes(Map<String, String> attributeMap) {
+
+        ValidationResult validationResult = new ValidationResult(true);
+
+        validateAttributeExistence(ATTRIBUTE_USERNAME, attributeMap, validationResult);
+        validateAttributeExistence(ATTRIBUTE_PASSWORD, attributeMap, validationResult);
+
+        return validationResult;
+    }
+
+    private AuthAttribute buildAuthAttribute(String name, boolean isConfidential) {
+
+        return new AuthAttribute(name, false, isConfidential, AuthAttributeType.STRING);
+    }
+
+    private void validateAttributeExistence(String attribute, Map<String, String> attributeMap,
+                                            ValidationResult validationResult) {
+
+        if (attributeMap == null || attributeMap.isEmpty() || !attributeMap.containsKey(attribute)) {
+            validationResult.setValid(false);
+            addFailureReason(validationResult, attribute, ERROR_CODE_ATTRIBUTE_NOT_FOUND);
+        } else if (StringUtils.isBlank(attributeMap.get(attribute))) {
+            validationResult.setValid(false);
+            addFailureReason(validationResult, attribute, ERROR_CODE_ATTRIBUTE_VALUE_EMPTY);
+        }
+    }
+
+    private void addFailureReason(ValidationResult validationResult, String attribute,
+                                  AuthAttributeHandlerConstants.ErrorMessages reason) {
+
+        validationResult.getValidationFailureReasons()
+                .add(new ValidationFailureReason(attribute, reason.getCode(), reason.getMessage()));
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorServiceComponent.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorServiceComponent.java
@@ -28,6 +28,8 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.application.authentication.framework.ApplicationAuthenticator;
 import org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticator;
+import org.wso2.carbon.identity.application.authenticator.basicauth.attribute.handler.BasicAuthAuthAttributeHandler;
+import org.wso2.carbon.identity.auth.attribute.handler.AuthAttributeHandler;
 import org.wso2.carbon.identity.captcha.util.CaptchaConstants;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -81,11 +83,14 @@ public class BasicAuthenticatorServiceComponent {
         try {
             BasicAuthenticator basicAuth = new BasicAuthenticator();
             ctxt.getBundleContext().registerService(ApplicationAuthenticator.class.getName(), basicAuth, null);
+
+            BasicAuthAuthAttributeHandler authAttributeHandler = new BasicAuthAuthAttributeHandler();
+            ctxt.getBundleContext().registerService(AuthAttributeHandler.class.getName(), authAttributeHandler, null);
             if (log.isDebugEnabled()) {
                 log.info("BasicAuthenticator bundle is activated");
             }
         } catch (Throwable e) {
-            log.error("SAMLSSO Authenticator bundle activation Failed", e);
+            log.error("BasicAuthenticator bundle activation Failed", e);
         }
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/attribute/handler/BasicAuthAuthAttributeHandlerTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/attribute/handler/BasicAuthAuthAttributeHandlerTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authenticator.basicauth.attribute.handler;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants;
+import org.wso2.carbon.identity.auth.attribute.handler.AuthAttributeHandlerBindingType;
+import org.wso2.carbon.identity.auth.attribute.handler.AuthAttributeHandlerConstants;
+import org.wso2.carbon.identity.auth.attribute.handler.model.AuthAttribute;
+import org.wso2.carbon.identity.auth.attribute.handler.model.AuthAttributeHolder;
+import org.wso2.carbon.identity.auth.attribute.handler.model.AuthAttributeType;
+import org.wso2.carbon.identity.auth.attribute.handler.model.ValidationFailureReason;
+import org.wso2.carbon.identity.auth.attribute.handler.model.ValidationResult;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.wso2.carbon.identity.auth.attribute.handler.AuthAttributeHandlerConstants.ErrorMessages.ERROR_CODE_ATTRIBUTE_NOT_FOUND;
+import static org.wso2.carbon.identity.auth.attribute.handler.AuthAttributeHandlerConstants.ErrorMessages.ERROR_CODE_ATTRIBUTE_VALUE_EMPTY;
+
+/**
+ * Test class for BasicAuthAuthAttributeHandler.
+ */
+public class BasicAuthAuthAttributeHandlerTest {
+
+    private static final String HANDLER_NAME = "BasicAuthAuthAttributeHandler";
+    private static final String ATTRIBUTE_USERNAME = "username";
+    private static final String ATTRIBUTE_PASSWORD = "password";
+    private static final String USERNAME_VALUE = "johndoe";
+    private static final String PASSWORD_VALUE = "asd!@31";
+    private static final BasicAuthAuthAttributeHandler HANDLER = new BasicAuthAuthAttributeHandler();
+
+    @Test
+    public void testGetName() {
+
+        Assert.assertEquals(HANDLER.getName(), HANDLER_NAME,
+                "Did not receive the expected auth attribute handler name.");
+    }
+
+    @Test
+    public void testGetBindingType() {
+
+        Assert.assertEquals(HANDLER.getBindingType(), AuthAttributeHandlerBindingType.AUTHENTICATOR,
+                "Did not receive the expected auth attribute binding type.");
+    }
+
+    @Test
+    public void testGetBoundIdentifier() {
+
+        Assert.assertEquals(HANDLER.getBoundIdentifier(), BasicAuthenticatorConstants.AUTHENTICATOR_NAME,
+                "Did not receive the expected bound identifier.");
+    }
+
+    @Test
+    public void testGetAuthAttributeData() {
+
+        AuthAttributeHolder holder = HANDLER.getAuthAttributeData();
+        Assert.assertEquals(holder.getHandlerName(), HANDLER_NAME,
+                "Did not receive the expected auth attribute handler name.");
+        Assert.assertEquals(holder.getHandlerBinding(), AuthAttributeHandlerBindingType.AUTHENTICATOR,
+                "Did not receive the expected auth attribute binding type.");
+        Assert.assertEquals(holder.getHandlerBoundIdentifier(), BasicAuthenticatorConstants.AUTHENTICATOR_NAME,
+                "Did not receive the expected bound identifier.");
+        Assert.assertEquals(holder.getProperties().size(), 0,
+                "Holder properties should be empty but contains values.");
+        Assert.assertEquals(holder.getAuthAttributes().size(), 2, "Unexpected number of auth attributes.");
+        for (AuthAttribute authAttribute : holder.getAuthAttributes()) {
+            AuthAttribute expectedAuthAttribute = getAuthAttribute(authAttribute.getAttribute());
+            String attribute = authAttribute.getAttribute();
+
+            Assert.assertNotNull(expectedAuthAttribute, String.format("Unexpected auth attribute %s available in " +
+                    "the auth attribute list", attribute));
+            Assert.assertEquals(authAttribute.isClaim(), expectedAuthAttribute.isClaim(),
+                    "Expected value not found for isClaim field of the auth attribute: " + attribute);
+            Assert.assertEquals(authAttribute.isConfidential(), expectedAuthAttribute.isConfidential(),
+                    "Expected value not found for isConfidential field of the auth attribute: " + attribute);
+            Assert.assertEquals(authAttribute.getType(), expectedAuthAttribute.getType(),
+                    "Expected value not found for type field of the auth attribute: " + attribute);
+            Assert.assertEquals(authAttribute.getProperties().size(), 0,
+                    String.format("Auth attribute: %s properties should be empty but contains values.", attribute));
+        }
+    }
+
+    @DataProvider
+    public Object[][] getAttributesAndExpectedResult() {
+
+        return new Object[][]{
+                {buildAttributeMap(USERNAME_VALUE, PASSWORD_VALUE), new ValidationResult(true)},
+                {buildAttributeMap(USERNAME_VALUE, null, false),
+                        buildFailedValidationResult(null, ERROR_CODE_ATTRIBUTE_NOT_FOUND)},
+                {buildAttributeMap(USERNAME_VALUE, null),
+                        buildFailedValidationResult(null, ERROR_CODE_ATTRIBUTE_VALUE_EMPTY)},
+                {buildAttributeMap(USERNAME_VALUE, " "),
+                        buildFailedValidationResult(null, ERROR_CODE_ATTRIBUTE_VALUE_EMPTY)},
+                {buildAttributeMap(null, PASSWORD_VALUE, false),
+                        buildFailedValidationResult(ERROR_CODE_ATTRIBUTE_NOT_FOUND, null)},
+                {buildAttributeMap(null, PASSWORD_VALUE),
+                        buildFailedValidationResult(ERROR_CODE_ATTRIBUTE_VALUE_EMPTY, null)},
+                {buildAttributeMap(" ", USERNAME_VALUE),
+                        buildFailedValidationResult(ERROR_CODE_ATTRIBUTE_VALUE_EMPTY, null)},
+                {buildAttributeMap(null, null, false),
+                        buildFailedValidationResult(ERROR_CODE_ATTRIBUTE_NOT_FOUND, ERROR_CODE_ATTRIBUTE_NOT_FOUND)},
+                {buildAttributeMap("", ""), buildFailedValidationResult(ERROR_CODE_ATTRIBUTE_VALUE_EMPTY,
+                        ERROR_CODE_ATTRIBUTE_VALUE_EMPTY)},
+                {MapUtils.EMPTY_MAP, buildFailedValidationResult(ERROR_CODE_ATTRIBUTE_NOT_FOUND,
+                        ERROR_CODE_ATTRIBUTE_NOT_FOUND)},
+                {null, buildFailedValidationResult(ERROR_CODE_ATTRIBUTE_NOT_FOUND, ERROR_CODE_ATTRIBUTE_NOT_FOUND)},
+        };
+    }
+
+    @Test(dataProvider = "getAttributesAndExpectedResult")
+    public void testValidateAttributes(Object attributeMap, Object expectedResult) {
+
+        ValidationResult expectedRes = (ValidationResult) expectedResult;
+        try {
+            ValidationResult validationResult = HANDLER.validateAttributes((Map<String, String>) attributeMap);
+
+            if (validationResult.isValid() != expectedRes.isValid()) {
+                Assert.fail(String.format("Expected isValid to be: %s actual isValid: %s", validationResult.isValid(),
+                        expectedRes.isValid()));
+            }
+
+            if (!validationResult.isValid() &&
+                    CollectionUtils.isEmpty(validationResult.getValidationFailureReasons())) {
+                Assert.fail("validationFailureReasons should not be empty.");
+            }
+
+            if (validationResult.isValid() &&
+                    CollectionUtils.isNotEmpty(validationResult.getValidationFailureReasons())) {
+                Assert.fail("validationFailureReasons should be empty.");
+            }
+
+            if (!validationResult.isValid()) {
+                // Check if expected failure reasons are not present.
+                for (ValidationFailureReason eReason : expectedRes.getValidationFailureReasons()) {
+                    boolean foundExpectedFailure = false;
+                    for (ValidationFailureReason aReason : validationResult.getValidationFailureReasons()) {
+                        if (eReason.getErrorCode().equals(aReason.getErrorCode()) &&
+                                eReason.getAuthAttribute().equals(aReason.getAuthAttribute()) &&
+                                eReason.getReason().equals(aReason.getReason())) {
+                            foundExpectedFailure = true;
+                        }
+                    }
+                    if (!foundExpectedFailure) {
+                        Assert.fail(String.format("Expected errorCode: %s with reason: '%s' not found for attribute: " +
+                                        "%s",
+                                eReason.getErrorCode(), eReason.getReason(), eReason.getAuthAttribute()));
+                    }
+                }
+
+                // Check if unexpected failure reasons are present.
+                for (ValidationFailureReason aReason : validationResult.getValidationFailureReasons()) {
+                    boolean foundUnexpectedFailure = true;
+                    for (ValidationFailureReason eReason : expectedRes.getValidationFailureReasons()) {
+                        if (aReason.getErrorCode().equals(eReason.getErrorCode()) &&
+                                aReason.getAuthAttribute().equals(eReason.getAuthAttribute()) &&
+                                aReason.getReason().equals(eReason.getReason())) {
+                            foundUnexpectedFailure = false;
+                        }
+                    }
+                    if (foundUnexpectedFailure) {
+                        Assert.fail(String.format("Unexpected errorCode: %s with reason: '%s' found for attribute: %s",
+                                aReason.getErrorCode(), aReason.getReason(), aReason.getAuthAttribute()));
+                    }
+                }
+            }
+        } catch (Exception e) {
+            Assert.fail("Test threw an unexpected exception.", e);
+        }
+    }
+
+    private AuthAttribute getAuthAttribute(String name) {
+
+        List<AuthAttribute> authAttributes = getAuthAttributes();
+        for (AuthAttribute authAttribute : authAttributes) {
+            if (StringUtils.equals(authAttribute.getAttribute(), name)) {
+                return authAttribute;
+            }
+        }
+        return null;
+    }
+
+    private List<AuthAttribute> getAuthAttributes() {
+
+        List<AuthAttribute> authAttributes = new ArrayList<>();
+
+        authAttributes.add(buildAuthAttribute(ATTRIBUTE_USERNAME, false));
+        authAttributes.add(buildAuthAttribute(ATTRIBUTE_PASSWORD, true));
+
+        return authAttributes;
+    }
+
+    private AuthAttribute buildAuthAttribute(String name, boolean isConfidential) {
+
+        return new AuthAttribute(name, false, isConfidential, AuthAttributeType.STRING);
+    }
+
+    private Map<String, String> buildAttributeMap(String usernameVal, String passwordVal, boolean addNullAttributes) {
+
+        Map<String, String> attributeMap = new HashMap<>();
+        if (usernameVal != null || addNullAttributes) {
+            attributeMap.put(ATTRIBUTE_USERNAME, usernameVal);
+        }
+        if (passwordVal != null || addNullAttributes) {
+            attributeMap.put(ATTRIBUTE_PASSWORD, passwordVal);
+        }
+
+        return attributeMap;
+    }
+
+    private Map<String, String> buildAttributeMap(String usernameVal, String passwordVal) {
+
+        return buildAttributeMap(usernameVal, passwordVal, true);
+    }
+
+    private ValidationResult buildFailedValidationResult(AuthAttributeHandlerConstants.ErrorMessages unError,
+                                                         AuthAttributeHandlerConstants.ErrorMessages pwError) {
+
+        ValidationResult validationResult = new ValidationResult(false);
+
+        if (unError != null) {
+            validationResult.getValidationFailureReasons().add(
+                    new ValidationFailureReason(ATTRIBUTE_USERNAME, unError.getCode(), unError.getMessage()));
+        }
+
+        if (pwError != null) {
+            validationResult.getValidationFailureReasons().add(
+                    new ValidationFailureReason(ATTRIBUTE_PASSWORD, pwError.getCode(), pwError.getMessage()));
+        }
+
+        return validationResult;
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/resources/testng.xml
@@ -26,6 +26,7 @@
         <classes>
             <class name="org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorTestCase"/>
             <class name="org.wso2.carbon.identity.application.authenticator.basicauth.internal.BasicAuthenticatorServiceComponentTestCase"/>
+            <class name="org.wso2.carbon.identity.application.authenticator.basicauth.attribute.handler.BasicAuthAuthAttributeHandlerTest"/>
         </classes>
     </test>
 
@@ -34,6 +35,7 @@
         <classes>
             <class name="org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorTestCase"/>
             <class name="org.wso2.carbon.identity.application.authenticator.basicauth.internal.BasicAuthenticatorServiceComponentTestCase"/>
+            <class name="org.wso2.carbon.identity.application.authenticator.basicauth.attribute.handler.BasicAuthAuthAttributeHandlerTest"/>
         </classes>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,11 @@
                 <version>${identity.governance.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.governance</groupId>
+                <artifactId>org.wso2.carbon.identity.auth.attribute.handler</artifactId>
+                <version>${identity.governance.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.multi.attribute.login.mgt</artifactId>
                 <version>${carbon.identity.framework.version}</version>
@@ -350,7 +355,7 @@
         <carbon.identity.framework.imp.pkg.version.range>[5.19.14, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
-        <identity.governance.version>1.8.11</identity.governance.version>
+        <identity.governance.version>1.8.21</identity.governance.version>
         <identity.governance.imp.pkg.version.range>[1.5.89, 2.0.0)</identity.governance.imp.pkg.version.range>
 
         <osgi.framework.imp.pkg.version.range>[1.7.0, 2.0.0)</osgi.framework.imp.pkg.version.range>


### PR DESCRIPTION
This PR adds the auth attribute handler component related to the basic authenticator. Refer https://github.com/wso2-extensions/identity-governance/pull/651 description to get an idea on how the auth attribute handler works.

The component sends the following attributes as auth attributes for basic authenticator
- `username`
- `password`

The following validations are done when the validate attribute method of this auth attribute handler is called.

- Check if required auth attributes are provided.
- Check if provided required auth attributes are not blank.


Related to: https://github.com/wso2/product-is/issues/15449