### PR TITLE
Get tenant domain from MultitenantUtils in Multi Attribute Login

### DIFF
--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
@@ -386,16 +386,16 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
             username = FrameworkUtils.preprocessUsername(identifierFromRequest, context);
         }
 
+        String tenantDomain = MultitenantUtils.getTenantDomain(username);
         String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
         String userId = null;
         if (IdentifierAuthenticatorServiceComponent.getMultiAttributeLogin().isEnabled(context.getTenantDomain())) {
             ResolvedUserResult resolvedUserResult = IdentifierAuthenticatorServiceComponent.getMultiAttributeLogin().
-                    resolveUser(MultitenantUtils.getTenantAwareUsername(username), context.getTenantDomain());
+                    resolveUser(tenantAwareUsername, tenantDomain);
             if (resolvedUserResult != null && ResolvedUserResult.UserResolvedStatus.SUCCESS.
                     equals(resolvedUserResult.getResolvedStatus())) {
                 tenantAwareUsername = resolvedUserResult.getUser().getUsername();
-                username = UserCoreUtil.addTenantDomainToEntry(resolvedUserResult.getUser().getUsername(),
-                        context.getTenantDomain());
+                username = UserCoreUtil.addTenantDomainToEntry(tenantAwareUsername, tenantDomain);
                 userId = resolvedUserResult.getUser().getUserID();
             } else {
                 context.setProperty(IS_INVALID_USERNAME, true);
@@ -442,7 +442,6 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
             }
         }
 
-        String tenantDomain = MultitenantUtils.getTenantDomain(username);
         Map<String, Object> authProperties = context.getProperties();
         if (authProperties == null) {
             authProperties = new HashMap<>();


### PR DESCRIPTION
## Purpose
Currently in the identifier first authenticator for Multi Attribute Login the tenant domain is taken from context. With this, for SaaS applications if a user from another tenant tries to log into an application registered in super tenant (or some other tenant), the user cannot be resolved since the tenant domain in context is not that of the user trying to log in. To fix this, when resolving the user, the user's tenant domain is set using MultitenantUtils.

## Related Issues
- Issue https://github.com/wso2/product-is/issues/15423
- Issue https://github.com/wso2/product-is/issues/15422