### PR TITLE
Fix the validating user from IDF handler

### DIFF
--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
@@ -395,6 +395,11 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
         String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
         String userId = null;
         String userStoreDomain = null;
+
+        /*
+         This is going to be removed after the multi attribute user resolving logic is moved to each authenticator.
+         Hence, don't rely on this logic for new authenticators.
+         */
         if (IdentifierAuthenticatorServiceComponent.getMultiAttributeLogin().isEnabled(context.getTenantDomain())) {
             ResolvedUserResult resolvedUserResult = IdentifierAuthenticatorServiceComponent.getMultiAttributeLogin().
                     resolveUser(tenantAwareUsername, tenantDomain);
@@ -404,10 +409,6 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
                 username = UserCoreUtil.addTenantDomainToEntry(tenantAwareUsername, tenantDomain);
                 userId = resolvedUserResult.getUser().getUserID();
                 userStoreDomain = resolvedUserResult.getUser().getUserStoreDomain();
-            } else {
-                context.setProperty(IS_INVALID_USERNAME, true);
-                throw new InvalidCredentialsException(ErrorMessages.USER_DOES_NOT_EXISTS.getCode(),
-                        ErrorMessages.USER_DOES_NOT_EXISTS.getMessage(), User.getUserFromUserName(username));
             }
         }
 

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
@@ -72,6 +72,7 @@ import javax.servlet.http.HttpServletResponse;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.IDENTIFIER_CONSENT;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.RESTART_FLOW;
 import static org.wso2.carbon.identity.application.authentication.handler.identifier.IdentifierHandlerConstants.IS_INVALID_USERNAME;
+import static org.wso2.carbon.identity.application.authentication.handler.identifier.IdentifierHandlerConstants.IS_USER_RESOLVED;
 import static org.wso2.carbon.identity.application.authentication.handler.identifier.IdentifierHandlerConstants.USERNAME_USER_INPUT;
 import static org.wso2.carbon.user.core.UserCoreConstants.DOMAIN_SEPARATOR;
 import static org.wso2.carbon.user.core.UserCoreConstants.RealmConfig.PROPERTY_DOMAIN_NAME;
@@ -409,6 +410,8 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
                 username = UserCoreUtil.addTenantDomainToEntry(tenantAwareUsername, tenantDomain);
                 userId = resolvedUserResult.getUser().getUserID();
                 userStoreDomain = resolvedUserResult.getUser().getUserStoreDomain();
+                // Set a property to the context to indicate that the user is resolved from this step.
+                setIsUserResolvedToContext(context);
             }
         }
 
@@ -511,6 +514,16 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
         user.setUserStoreDomain(userStoreDomain);
         user.setTenantDomain(tenantDomain);
         context.setSubject(user);
+    }
+
+    private void setIsUserResolvedToContext(AuthenticationContext context) {
+
+        Map<String, Object> properties = context.getProperties();
+        if (properties == null) {
+            properties = new HashMap<>();
+        }
+        properties.put(IS_USER_RESOLVED, true);
+        context.setProperties(properties);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandlerConstants.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandlerConstants.java
@@ -33,6 +33,7 @@ public abstract class IdentifierHandlerConstants {
     public static final String UTF_8 = "UTF-8";
     public static final String IS_INVALID_USERNAME = "isInvalidUsername";
     public static final String USERNAME_USER_INPUT = "usernameUserInput";
+    public static final String IS_USER_RESOLVED = "isUserResolved";
 
     private IdentifierHandlerConstants() {
     }


### PR DESCRIPTION
### Purpose

- Default bahavior of the IDF handler is not validating the user from IDF handler.
- To fill he gaps, we are not validating the user when multi attribute login is enabled.
- From this PR, we are removing the error thrown from the IDF handler after validating the user.
- And we have added a new property to context to track that the user is resolved from the IDF or not ,
    -  When multi attribute login is enabled, the user is resolved from the IDF 
    -  Set `isUserResolved` as true as a property in context.
    - Check this property before resolving the user from relevant other authenticators.

## Related issue
https://github.com/wso2/product-is/issues/16302