### PR TITLE
Fix redirect URL in active session limit handler

### DIFF
--- a/components/org.wso2.carbon.identity.application.authentication.handler.session/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.session/pom.xml
@@ -122,6 +122,7 @@
                             org.wso2.carbon.identity.application.authentication.framework.util;version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.common.*;version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.base.*;version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.core;version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.model.*;version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.util;version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.*;version="${carbon.identity.framework.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.application.authentication.handler.session/src/main/java/org/wso2/carbon/identity/application/authentication/handler/session/ActiveSessionsLimitHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.session/src/main/java/org/wso2/carbon/identity/application/authentication/handler/session/ActiveSessionsLimitHandler.java
@@ -38,6 +38,8 @@ import org.wso2.carbon.identity.application.authentication.framework.util.Framew
 import org.wso2.carbon.identity.application.authentication.handler.session.exception.UserSessionRetrievalException;
 import org.wso2.carbon.identity.application.authentication.handler.session.exception.UserSessionTerminationException;
 import org.wso2.carbon.identity.application.authentication.handler.session.internal.ActiveSessionsLimitHandlerServiceHolder;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.model.UserAgent;
 
 import java.io.IOException;
@@ -147,7 +149,14 @@ public class ActiveSessionsLimitHandler extends AbstractApplicationAuthenticator
             Map<String, String> paramMap = new HashMap<>();
             paramMap.put(PROMPT_ID, context.getContextIdentifier());
             paramMap.put(SP_NAME, context.getServiceProviderName());
-            response.sendRedirect(FrameworkUtils.buildURLWithQueryParams(REDIRECT_URL, paramMap));
+            String redirectURL = FrameworkUtils.buildURLWithQueryParams(REDIRECT_URL, paramMap);
+            try {
+                redirectURL = ServiceURLBuilder.create().addPath(redirectURL).build().getAbsolutePublicURL();
+            } catch (URLBuilderException var4) {
+                throw new AuthenticationFailedException("Error while building tenant qualified url for context: "
+                        + REDIRECT_URL);
+            }
+            response.sendRedirect(redirectURL);
         } catch (IOException e) {
             throw new AuthenticationFailedException("Error occurred while redirecting to: " + REDIRECT_URL
                     + "?promptId=" + context.getContextIdentifier(), e);

--- a/components/org.wso2.carbon.identity.application.authentication.handler.session/src/main/java/org/wso2/carbon/identity/application/authentication/handler/session/ActiveSessionsLimitHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.session/src/main/java/org/wso2/carbon/identity/application/authentication/handler/session/ActiveSessionsLimitHandler.java
@@ -152,9 +152,9 @@ public class ActiveSessionsLimitHandler extends AbstractApplicationAuthenticator
             String redirectURL = FrameworkUtils.buildURLWithQueryParams(REDIRECT_URL, paramMap);
             try {
                 redirectURL = ServiceURLBuilder.create().addPath(redirectURL).build().getAbsolutePublicURL();
-            } catch (URLBuilderException var4) {
+            } catch (URLBuilderException e) {
                 throw new AuthenticationFailedException("Error while building tenant qualified url for context: "
-                        + REDIRECT_URL);
+                        + REDIRECT_URL, e);
             }
             response.sendRedirect(redirectURL);
         } catch (IOException e) {


### PR DESCRIPTION
## Purpose

In Asgardeo, when the ActiveSessionsLimitHandler is configured and when a user logins when the maximum allowed number of sessions are shown, they are redirected to `https://api.asgardeo.io/authenticationendpoint/handle-multiple-sessions.do?<query-params>`. 

The base URL is `api.asgardeo.io` where as in other pages related to login, the base URL is `accounts.asgardeo.io/t/<tenanted_path>`.

This PR fixes the redirect URL to be` https://accounts.asgardeo.io/t/<tenant_domain>/authenticationendpoint/handle-multiple-sessions.do?<query-params>`.

In addition, when the URL is tenant qualified, the tenant domain will be used to retrieve the branding configurations that should be applied for `handle-multiple-session.jsp`. This is similar to the way branding being applied to other pages.
