### PR TITLE
Support userstore preference order for multi-attribute login

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -612,35 +612,23 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
         if (BasicAuthenticatorDataHolder.getInstance().getMultiAttributeLogin().isEnabled(requestTenantDomain)) {
             try {
                 List<String> userStorePreferenceOrder = getUserStorePreferenceOrder();
-
-                if (userStorePreferenceOrder.isEmpty() || userStorePreferenceOrder.size() == 1) {
-                    ResolvedUserResult resolvedUserResult = null;
-                    if (userStorePreferenceOrder.isEmpty()) {
-                        resolvedUserResult = BasicAuthenticatorDataHolder.getInstance().getMultiAttributeLogin().
-                                resolveUser(tenantAwareUsername, requestTenantDomain);
-                    }
-                    if (userStorePreferenceOrder.size() == 1) {
-                        String allowedDomainName = userStorePreferenceOrder.get(0);
-                        String userStoreQualifiedUsername = UserCoreUtil.addDomainToName(tenantAwareUsername,
-                                allowedDomainName);
-                        resolvedUserResult = BasicAuthenticatorDataHolder.getInstance().getMultiAttributeLogin().
-                                resolveUser(userStoreQualifiedUsername, requestTenantDomain);
-                    }
-                    if (resolvedUserResult != null && ResolvedUserResult.UserResolvedStatus.SUCCESS.
-                            equals(resolvedUserResult.getResolvedStatus())) {
-                        tenantAwareUsername = resolvedUserResult.getUser().getUsername();
-                        username = UserCoreUtil.addTenantDomainToEntry(tenantAwareUsername, requestTenantDomain);
-                        userId = resolvedUserResult.getUser().getUserID();
-                    } else {
-                        context.setProperty(IS_INVALID_USERNAME, true);
-                        throw new InvalidCredentialsException(ErrorMessages.USER_DOES_NOT_EXISTS.getCode(),
-                                ErrorMessages.USER_DOES_NOT_EXISTS.getMessage(), User.getUserFromUserName(username));
-                    }
+                if (userStorePreferenceOrder.size() == 1) {
+                    String allowedDomainName = userStorePreferenceOrder.get(0);
+                    tenantAwareUsername = UserCoreUtil.addDomainToName(tenantAwareUsername,
+                            allowedDomainName);
+                }
+                ResolvedUserResult resolvedUserResult =
+                        BasicAuthenticatorDataHolder.getInstance().getMultiAttributeLogin()
+                                .resolveUser(tenantAwareUsername, requestTenantDomain);
+                if (resolvedUserResult != null && ResolvedUserResult.UserResolvedStatus.SUCCESS.
+                        equals(resolvedUserResult.getResolvedStatus())) {
+                    tenantAwareUsername = resolvedUserResult.getUser().getUsername();
+                    username = UserCoreUtil.addTenantDomainToEntry(tenantAwareUsername, requestTenantDomain);
+                    userId = resolvedUserResult.getUser().getUserID();
                 } else {
-                    throw new InvalidCredentialsException(
-                            ErrorMessages.MULTIPLE_USER_STORE_BINDING_FOR_SP_NOT_ALLOWED.getCode(),
-                            ErrorMessages.MULTIPLE_USER_STORE_BINDING_FOR_SP_NOT_ALLOWED.getMessage(),
-                            User.getUserFromUserName(username));
+                    context.setProperty(IS_INVALID_USERNAME, true);
+                    throw new InvalidCredentialsException(ErrorMessages.USER_DOES_NOT_EXISTS.getCode(),
+                            ErrorMessages.USER_DOES_NOT_EXISTS.getMessage(), User.getUserFromUserName(username));
                 }
             } catch (UserStoreException e) {
                 throw new AuthenticationFailedException(

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -1231,28 +1231,4 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                         applicationName));
 
     }
-
-    /**
-     * Retrieve user store preference order.
-     *
-     * @return User store preference order as a list.
-     * @throws UserStoreException If an error occurred while retrieving the user store preference order.
-     */
-    private List<String> getUserStorePreferenceOrder() throws UserStoreException {
-
-        UserMgtContext userMgtContext = UserCoreUtil.getUserMgtContextFromThreadLocal();
-        if (userMgtContext != null) {
-            // Retrieve the relevant supplier to generate the user store preference order.
-            UserStorePreferenceOrderSupplier<List<String>> userStorePreferenceSupplier = userMgtContext.
-                    getUserStorePreferenceOrderSupplier();
-            if (userStorePreferenceSupplier != null) {
-                // Generate the user store preference order.
-                List<String> userStorePreferenceOrder = userStorePreferenceSupplier.get();
-                if (userStorePreferenceOrder != null) {
-                    return userStorePreferenceOrder;
-                }
-            }
-        }
-        return Collections.emptyList();
-    }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -643,7 +643,6 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                             User.getUserFromUserName(username));
                 }
             } catch (UserStoreException e) {
-                log.error(ErrorMessages.USER_STORE_EXCEPTION_WHILE_TRYING_TO_AUTHENTICATE.getMessage());
                 throw new AuthenticationFailedException(
                         ErrorMessages.USER_STORE_EXCEPTION_WHILE_TRYING_TO_AUTHENTICATE.getCode(),
                         ErrorMessages.USER_STORE_EXCEPTION_WHILE_TRYING_TO_AUTHENTICATE.getMessage());

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -612,11 +612,6 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
         if (BasicAuthenticatorDataHolder.getInstance().getMultiAttributeLogin().isEnabled(requestTenantDomain)) {
             try {
                 List<String> userStorePreferenceOrder = getUserStorePreferenceOrder();
-                String userStoreQualifiedUsername = StringUtils.EMPTY;
-                if (userStorePreferenceOrder.size() == 1) {
-                    String allowedDomainName = userStorePreferenceOrder.get(0);
-                    userStoreQualifiedUsername = UserCoreUtil.addDomainToName(tenantAwareUsername, allowedDomainName);
-                }
 
                 if (userStorePreferenceOrder.isEmpty() || userStorePreferenceOrder.size() == 1) {
                     ResolvedUserResult resolvedUserResult = null;
@@ -625,6 +620,9 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                                 resolveUser(tenantAwareUsername, requestTenantDomain);
                     }
                     if (userStorePreferenceOrder.size() == 1) {
+                        String allowedDomainName = userStorePreferenceOrder.get(0);
+                        String userStoreQualifiedUsername = UserCoreUtil.addDomainToName(tenantAwareUsername,
+                                allowedDomainName);
                         resolvedUserResult = BasicAuthenticatorDataHolder.getInstance().getMultiAttributeLogin().
                                 resolveUser(userStoreQualifiedUsername, requestTenantDomain);
                     }

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/util/BasicAuthErrorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/util/BasicAuthErrorConstants.java
@@ -45,8 +45,6 @@ public class BasicAuthErrorConstants {
         // Organization management exception while resolving user's resident org.
         ORGANIZATION_MGT_EXCEPTION_WHILE_TRYING_TO_RESOLVE_RESIDENT_ORG("BAS-65022",
                 "Organization mgt exception while authenticating"),
-        MULTIPLE_USER_STORE_BINDING_FOR_SP_NOT_ALLOWED("BAS-65023",
-                "Multiple user store binding for SP is not allowed with multi attribute login."),
         // UserStore Error codes
         USER_DOES_NOT_EXISTS("17001", "User does not exists"),
         INVALID_CREDENTIALS("17002",

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/util/BasicAuthErrorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/util/BasicAuthErrorConstants.java
@@ -45,6 +45,8 @@ public class BasicAuthErrorConstants {
         // Organization management exception while resolving user's resident org.
         ORGANIZATION_MGT_EXCEPTION_WHILE_TRYING_TO_RESOLVE_RESIDENT_ORG("BAS-65022",
                 "Organization mgt exception while authenticating"),
+        MULTIPLE_USER_STORE_BINDING_FOR_SP_NOT_ALLOWED("BAS-65023",
+                "Multiple user store binding for SP is not allowed with multi attribute login."),
         // UserStore Error codes
         USER_DOES_NOT_EXISTS("17001", "User does not exists"),
         INVALID_CREDENTIALS("17002",


### PR DESCRIPTION
### Description
- Add support for multi-attribute login when user store preference order extension is used. 

### This PR should be merger after
- https://github.com/wso2/carbon-identity-framework/pull/4985

Resolves https://github.com/wso2/product-is/issues/12503