### PR TITLE
Support basic authenticator to authenticate by providing username and password as runtime params

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -39,12 +39,13 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorMessage;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatorParamMetadata;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.basicauth.internal.BasicAuthenticatorDataHolder;
 import org.wso2.carbon.identity.application.authenticator.basicauth.internal.BasicAuthenticatorServiceComponent;
 import org.wso2.carbon.identity.application.authenticator.basicauth.util.AutoLoginConstant;
-import org.wso2.carbon.identity.application.authenticator.basicauth.util.BasicAuthErrorConstants.ErrorMessages;
 import org.wso2.carbon.identity.application.authenticator.basicauth.util.AutoLoginUtilities;
+import org.wso2.carbon.identity.application.authenticator.basicauth.util.BasicAuthErrorConstants.ErrorMessages;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
@@ -81,8 +82,8 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Optional;
+import java.util.Properties;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -94,26 +95,26 @@ import static org.wso2.carbon.identity.application.authenticator.basicauth.Basic
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.ACCOUNT_LOCKED_REASON;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.ACCOUNT_PENDING_APPROVAL;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.AUTHENTICATOR_BASIC;
+import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.AUTHENTICATOR_MESSAGE;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.DISPLAY_PASSWORD;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.DISPLAY_USER_NAME;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.FORCED_PASSWORD_RESET_VIA_EMAIL;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.FORCED_PASSWORD_RESET_VIA_OTP;
-import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.AUTHENTICATOR_MESSAGE;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.INVALID_CREDENTIALS_ARE_PROVIDED;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.IS_INVALID_USERNAME;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.OTP_MISMATCH_IN_ADMIN_FORCED_PASSWORD_RESET;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.PASSWORD;
+import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.RESOURCE_NAME_CONFIG;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.RESOURCE_TYPE_NAME_CONFIG;
-import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.PENDING_USER_INFORMATION_ATTRIBUTE_NAME_CONFIG;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.SHOW_PENDING_USER_INFORMATION_CONFIG;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.SHOW_PENDING_USER_INFORMATION_DEFAULT_VALUE;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.USERNAME_USER_INPUT;
 import static org.wso2.carbon.identity.application.authenticator.basicauth.BasicAuthenticatorConstants.USER_NAME;
-import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_ATTRIBUTE_DOES_NOT_EXISTS;
-import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
 import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_FEATURE_NOT_ENABLED;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_DOES_NOT_EXISTS;
+import static org.wso2.carbon.identity.configuration.mgt.core.constant.ConfigurationConstants.ErrorMessages.ERROR_CODE_RESOURCE_TYPE_DOES_NOT_EXISTS;
 
 /**
  * Username Password based Authenticator.
@@ -167,7 +168,7 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
             return AuthenticatorFlowStatus.INCOMPLETE;
         }
         Cookie autoLoginCookie = AutoLoginUtilities.getAutoLoginCookie(request.getCookies());
-
+        Map<String, String> runtimeParams = getRuntimeParams(context);
         if (context.isLogoutRequest()) {
             return AuthenticatorFlowStatus.SUCCESS_COMPLETED;
         } else if (autoLoginCookie != null && !Boolean.TRUE.equals(
@@ -198,7 +199,26 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
             } finally {
                 AutoLoginUtilities.removeAutoLoginCookieInResponse(response, autoLoginCookie);
             }
+        } else if (runtimeParams.containsKey(USER_NAME) && runtimeParams.containsKey(PASSWORD)) {
+            processAuthenticationResponse(request, response, context);
+            if (!context.getSequenceConfig().getApplicationConfig().isSaaSApp()) {
+                String userDomain = context.getSubject().getTenantDomain();
+                String tenantDomain = context.getTenantDomain();
+                if (!StringUtils.equals(userDomain, tenantDomain)) {
+                    context.setProperty(FrameworkConstants.USER_TENANT_DOMAIN_MISMATCH, true);
+                    throw new AuthenticationFailedException(
+                            FrameworkErrorConstants.ErrorMessages.MISMATCHING_TENANT_DOMAIN.getCode(),
+                            FrameworkErrorConstants.ErrorMessages.MISMATCHING_TENANT_DOMAIN.getMessage(),
+                            context.getSubject());
+                }
+            }
+
+            request.setAttribute(FrameworkConstants.REQ_ATTR_HANDLED, true);
+            context.setProperty(FrameworkConstants.LAST_FAILED_AUTHENTICATOR, null);
+            publishAuthenticationStepAttempt(request, context, context.getSubject(), true);
+            return AuthenticatorFlowStatus.SUCCESS_COMPLETED;
         }
+
         return super.process(request, response, context);
     }
 
@@ -618,8 +638,11 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
         if (StringUtils.isNotBlank(captchaParamString)) {
             context.setProperty(FrameworkConstants.CAPTCHA_PARAM_STRING, captchaParamString);
         }
-
+        Map<String, String> runtimeParameters = getRuntimeParams(context);
         String loginIdentifierFromRequest = request.getParameter(USER_NAME);
+        if (StringUtils.isBlank(loginIdentifierFromRequest)) {
+            loginIdentifierFromRequest = runtimeParameters.get(USER_NAME);
+        }
         if (StringUtils.isBlank(loginIdentifierFromRequest)) {
             throw new InvalidCredentialsException(ErrorMessages.EMPTY_USERNAME.getCode(),
                     ErrorMessages.EMPTY_USERNAME.getMessage());
@@ -672,6 +695,9 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
         }
         String password = request.getParameter(PASSWORD);
         if (StringUtils.isBlank(password)) {
+            password = runtimeParameters.get(PASSWORD);
+        }
+        if (StringUtils.isBlank(password)) {
             throw new InvalidCredentialsException(ErrorMessages.EMPTY_PASSWORD.getCode(),
                     ErrorMessages.EMPTY_PASSWORD.getMessage());
         }
@@ -683,7 +709,10 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
 
         if (runtimeParams != null) {
             String usernameFromContext = runtimeParams.get(FrameworkConstants.JSAttributes.JS_OPTIONS_USERNAME);
-            if (usernameFromContext != null &&
+            // Check whether Username set for identifier first login and username submitted from login page does not
+            // match. If the username submitted by login page is null, then the username from the context will be
+            // considered as the username submitted from the login page.
+            if (request.getParameter(USER_NAME) != null && usernameFromContext != null &&
                     !usernameFromContext.equals(request.getParameter(USER_NAME))) {
                 if (log.isDebugEnabled()) {
                     log.debug("Username set for identifier first login: " + usernameFromContext + " and username " +


### PR DESCRIPTION
## Purpose
> Provide support to basic authenticator to authenticate a user by providing username and password as runtime params from the adaptive script


## Approach
> Currently, we get the username from HttpServletRequest. With this fix, we check if the username and password contains in  runtime params. If those contains as a runtime param, we will use those values to continue the authentication. 
