### PR TITLE
Set IsUserResolve context parameter in ValidateUsername

### DIFF
--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
@@ -638,6 +638,7 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
             if (StringUtils.isNotEmpty(userDetails[1])) {
                 userStoreDomain = userDetails[1];
             }
+            setIsUserResolvedToContext(context);
 
             // TODO: user tenant domain has to be an attribute in the AuthenticationContext.
             authProperties.put("user-tenant-domain", tenantDomain);


### PR DESCRIPTION
## Purpose

Use `IsUserResolve` context parameter (which was already introduced for multi attribute login feature[1]) for identify weather the user was already resolved in the IDF authenticator and, based on that context parameter, not going to resolve the user again in the Email OTP & SMSOTP authenticators( similar to [2]).

[1] https://github.com/wso2-extensions/identity-local-auth-basicauth/blob/master/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java#L557-L558

[2] https://github.com/wso2-extensions/identity-outbound-auth-email-otp/blob/master/component/authenticator/src/main/java/org/wso2/carbon/identity/authenticator/emailotp/EmailOTPAuthenticator.java#L184-L185

## Related Issue

- https://github.com/wso2/product-is/issues/20466