### PR TITLE
Handle NPE which can be occurred when processing boolean value in the context

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -635,7 +635,7 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
         Map<String, String> runtimeParams = getRuntimeParams(context);
         String loginIdentifierFromRequest = request.getParameter(USER_NAME);
         if (StringUtils.isBlank(loginIdentifierFromRequest) &&
-                (Boolean) context.getProperty(RESOLVE_CREDENTIALS_FROM_RUNTIME_PARAMS)) {
+                Boolean.TRUE.equals(context.getProperty(RESOLVE_CREDENTIALS_FROM_RUNTIME_PARAMS))) {
             loginIdentifierFromRequest = runtimeParams.get(USER_NAME);
         }
         if (StringUtils.isBlank(loginIdentifierFromRequest)) {
@@ -688,7 +688,8 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
             }
         }
         String password = request.getParameter(PASSWORD);
-        if (StringUtils.isBlank(password) && (Boolean) context.getProperty(RESOLVE_CREDENTIALS_FROM_RUNTIME_PARAMS)) {
+        if (StringUtils.isBlank(password) &&
+                Boolean.TRUE.equals(context.getProperty(RESOLVE_CREDENTIALS_FROM_RUNTIME_PARAMS))) {
             password = runtimeParams.get(PASSWORD);
             context.removeProperty(RESOLVE_CREDENTIALS_FROM_RUNTIME_PARAMS);
         }


### PR DESCRIPTION
## Purpose
> $subject

If the `context.getProperty(RESOLVE_CREDENTIALS_FROM_RUNTIME_PARAMS)` is null, when casting to Boolean it will be null. Hence when evaluating the if condition, there is a possibility of NPE.