### PR TITLE
Append sub-org ID to username when domain validation is disabled

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2014-2024, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -664,12 +664,10 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
             }
         }
 
-        String username = loginIdentifierFromRequest;
+        String username = FrameworkUtils.preprocessUsername(loginIdentifierFromRequest, context);
         if (!IdentityUtil.isEmailUsernameValidationDisabled()) {
             FrameworkUtils.validateUsername(loginIdentifierFromRequest, context);
-            username = FrameworkUtils.preprocessUsername(loginIdentifierFromRequest, context);
         }
-
         String requestTenantDomain = MultitenantUtils.getTenantDomain(username);
         String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(username);
         String userId = null;


### PR DESCRIPTION
### Purpose
&subject

Fixes: https://github.com/wso2/product-is/issues/21504

This will also fix the flow for other tenants. 

## Goals
The current implementation of the basic authenticator skips the **preprocessUsername** method, which appends the sub-organization ID to the username. Without this appended ID, the userstore manager cannot locate the user in the correct organization. This causes the authentication status to be set as "FAIL", resulting in an authentication failure.

## Approach
Move the preprocessUsername method call outside the if-condition.