### PR TITLE
[Public] Fix accepting user credentials in query parameters

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -127,8 +127,9 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                                            HttpServletResponse response, AuthenticationContext context)
             throws AuthenticationFailedException, LogoutFailedException {
 
-        if (isURLContainSensitiveData(request, response, context)) {
-           return AuthenticatorFlowStatus.INCOMPLETE;
+        if (!IdentityUtil.shouldAllowSensitiveDataInURL() &&
+                isURLContainSensitiveData(request, response, context)) {
+            return AuthenticatorFlowStatus.INCOMPLETE;
         }
         Cookie autoLoginCookie = AutoLoginUtilities.getAutoLoginCookie(request.getCookies());
 
@@ -1034,6 +1035,16 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
         return MultitenantUtils.getTenantDomain(username);
     }
 
+    /**
+     * Checks if the URL contains sensitive data such as username or password and redirects the user
+     * to the login page with an error message if such data is found.
+     *
+     * @param request  the HTTP request object containing the query parameters to validate.
+     * @param response the HTTP response object used for redirection in case sensitive data is detected.
+     * @param context  the authentication context providing additional information for redirection.
+     * @return true if sensitive data is detected in the URL and the user is redirected; false otherwise.
+     * @throws AuthenticationFailedException if an error occurs during redirection.
+     */
     private boolean isURLContainSensitiveData(HttpServletRequest request, HttpServletResponse response,
                                               AuthenticationContext context) throws AuthenticationFailedException {
 

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
@@ -1641,4 +1641,42 @@ public class BasicAuthenticatorTestCase {
             return null;
         }).when(mockResponse).sendRedirect(anyString());
     }
+
+    @Test
+    public void testProcessWithSensitiveDataInURLWhenNotAllowed() throws AuthenticationFailedException,
+            LogoutFailedException {
+
+        try (MockedStatic<IdentityUtil> identityUtil = Mockito.mockStatic(IdentityUtil.class);) {
+            mockAuthnCtxt = mock(AuthenticationContext.class);
+            mockRequest = mock(HttpServletRequest.class);
+            mockResponse = mock(HttpServletResponse.class);
+            identityUtil.when(IdentityUtil::shouldAllowSensitiveDataInURL).thenReturn(false);
+
+            String queryString = BasicAuthenticatorConstants.USER_NAME + "=" + DUMMY_USER_NAME + "&" +
+                    BasicAuthenticatorConstants.PASSWORD + "=" + DUMMY_PASSWORD;
+            when(mockRequest.getQueryString()).thenReturn(queryString);
+            assertEquals(basicAuthenticator.process(mockRequest, mockResponse, mockAuthnCtxt),
+                    AuthenticatorFlowStatus.INCOMPLETE);
+        }
+    }
+
+    @Test
+    public void testProcessWithSensitiveDataInURLWhenAllowed() throws AuthenticationFailedException,
+            LogoutFailedException {
+
+        try (MockedStatic<IdentityUtil> identityUtil = Mockito.mockStatic(IdentityUtil.class);) {
+            mockAuthnCtxt = mock(AuthenticationContext.class);
+            mockRequest = mock(HttpServletRequest.class);
+            mockResponse = mock(HttpServletResponse.class);
+
+            identityUtil.when(IdentityUtil::shouldAllowSensitiveDataInURL).thenReturn(true);
+
+            String queryString = BasicAuthenticatorConstants.USER_NAME + "=" + DUMMY_USER_NAME + "&" +
+                    BasicAuthenticatorConstants.PASSWORD + "=" + DUMMY_PASSWORD;
+            when(mockRequest.getQueryString()).thenReturn(queryString);
+            when(mockAuthnCtxt.isLogoutRequest()).thenReturn(true);
+            assertEquals(basicAuthenticator.process(mockRequest, mockResponse, mockAuthnCtxt),
+                    AuthenticatorFlowStatus.SUCCESS_COMPLETED);
+        }
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.25.90</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.716</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.19.14, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.25.716</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.717</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.19.14, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION

### Purpose
This PR prevents processing sensitive data (eg: username, password) sent as query parameters in requests by checking for their availability in the query string part of the request.