### PR TITLE
Rename Auto Login Flows

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/util/AutoLoginConstant.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/util/AutoLoginConstant.java
@@ -33,8 +33,8 @@ public class AutoLoginConstant {
     public static final String DOMAIN = "domain";
     public static final String FLOW_TYPE = "flowType";
     public static final String CREATED_TIME = "createdTime";
-    public static final String SIGNUP = "SIGNUP";
-    public static final String RECOVERY = "RECOVERY";
+    public static final String SIGNUP = "SELF_SIGNUP";
+    public static final String RECOVERY = "ACCOUNT_RECOVERY";
     public static final String DEFAULT_COOKIE_MAX_AGE = "300";
     public static final String IDF_AUTO_LOGIN_FLOW_HANDLED = "idfAutoLoginHandled";
     public static final String BASIC_AUTH_AUTO_LOGIN_FLOW_HANDLED = "basicAuthAutoLoginHandled";


### PR DESCRIPTION
## Purpose 
Auto login feature login flows use different names compared in prior product versions. To keep the changes consistent update the auto login flow names.

## Related Issue 
- https://github.com/wso2/product-is/issues/23119

## Related PR/s
- https://github.com/wso2/identity-apps/pull/7658