### PR TITLE
Fix prompting active session handler for single sign on logins

### DIFF
--- a/components/org.wso2.carbon.identity.application.authentication.handler.session/src/main/java/org/wso2/carbon/identity/application/authentication/handler/session/ActiveSessionsLimitHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.session/src/main/java/org/wso2/carbon/identity/application/authentication/handler/session/ActiveSessionsLimitHandler.java
@@ -504,7 +504,7 @@ public class ActiveSessionsLimitHandler extends AbstractApplicationAuthenticator
     private boolean isSingleSignOnAttempt(AuthenticationContext context, List<UserSession> userSessions) {
 
         String sessionIdFromContext = context.getSessionIdentifier();
-        if (userSessions != null && StringUtils.isNotBlank(sessionIdFromContext)) {
+        if (StringUtils.isNotBlank(sessionIdFromContext)) {
             return userSessions.stream()
                     .anyMatch(userSession -> sessionIdFromContext.equals(userSession.getSessionId()));
         }

--- a/components/org.wso2.carbon.identity.application.authentication.handler.session/src/main/java/org/wso2/carbon/identity/application/authentication/handler/session/ActiveSessionsLimitHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.session/src/main/java/org/wso2/carbon/identity/application/authentication/handler/session/ActiveSessionsLimitHandler.java
@@ -18,7 +18,7 @@
 
 package org.wso2.carbon.identity.application.authentication.handler.session;
 
-import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -60,7 +60,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -505,12 +504,9 @@ public class ActiveSessionsLimitHandler extends AbstractApplicationAuthenticator
     private boolean isSingleSignOnAttempt(AuthenticationContext context, List<UserSession> userSessions) {
 
         String sessionIdFromContext = context.getSessionIdentifier();
-        if (sessionIdFromContext != null) {
-            for (UserSession userSession : userSessions) {
-                if (sessionIdFromContext.equals(userSession.getSessionId())) {
-                    return true;
-                }
-            }
+        if (userSessions != null && StringUtils.isNotBlank(sessionIdFromContext)) {
+            return userSessions.stream()
+                    .anyMatch(userSession -> sessionIdFromContext.equals(userSession.getSessionId()));
         }
         return false;
     }


### PR DESCRIPTION
## Purpose
> Currently when a user has already created session in an application with an authenticator in the first step and when that same user tries to login to another application which has the previous authenticator + another authenticator + Active Session Limit Handler in authentication steps, it prompts for session termination UI when the max session limit is set to 1. In this kind of scenarios, new session is not created if we forget about the session limiter. So, if the login attempt is a single sign on attempt, ideally session termination prompt should not be prompted. With this PR, if the login attempt is a single sign on attempt, it will be not considered for active session limit.

Related Issue - https://github.com/wso2/product-is/issues/23391

This is also been addressed with https://github.com/wso2-extensions/identity-local-auth-basicauth/pull/224 PR, but we need to consider the scenario of using session id based SSO scenario.