### PR TITLE
build the recovery url from the configuration facade.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -123,7 +123,7 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
 
     private static final long serialVersionUID = 1819664539416029785L;
     private static final String PASSWORD_PROPERTY = "PASSWORD_PROPERTY";
-    private static final String PASSWORD_RESET_ENDPOINT = "accountrecoveryendpoint/confirmrecovery.do?";
+    private static final String CONFIRM_RECOVERY_DO = "/confirmrecovery.do?";
     private static final Log log = LogFactory.getLog(BasicAuthenticator.class);
     private static final String RESEND_CONFIRMATION_RECAPTCHA_ENABLE = "SelfRegistration.ResendConfirmationReCaptcha";
     private static final String APPEND_USER_TENANT_TO_USERNAME = "appendUserTenantToUsername";
@@ -302,6 +302,7 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
         }
 
         String loginPage = ConfigurationFacade.getInstance().getAuthenticationEndpointURL();
+        String recoveryPage = ConfigurationFacade.getInstance().getAccountRecoveryEndpointPath();
         String retryPage = ConfigurationFacade.getInstance().getAuthenticationEndpointRetryURL();
         String queryParams = context.getContextIdIncludedQueryParams();
         String password = (String) context.getProperty(PASSWORD_PROPERTY);
@@ -423,7 +424,7 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                             BasicAuthenticatorConstants.LOCAL;
                     String reason = RecoveryScenarios.ADMIN_FORCED_PASSWORD_RESET_VIA_OTP.name();
 
-                    redirectURL = PASSWORD_RESET_ENDPOINT +
+                    redirectURL = recoveryPage + CONFIRM_RECOVERY_DO +
                             BasicAuthenticatorConstants.USER_NAME_PARAM + URLEncoder.encode(username,
                             BasicAuthenticatorConstants.UTF_8) + BasicAuthenticatorConstants.TENANT_DOMAIN_PARAM +
                             URLEncoder.encode(tenantDomain, BasicAuthenticatorConstants.UTF_8) +

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorTestCase.java
@@ -188,6 +188,7 @@ public class BasicAuthenticatorTestCase {
     private static final String DUMMY_PASSWORD = "dummyPassword";
     private static final String DUMMY_QUERY_PARAMS = "dummyQueryParams";
     private static final String DUMMY_LOGIN_PAGEURL = "dummyLoginPageurl";
+    private static final String DUMMY_RECOVERY_URL = "dummyRecoveryUrl";
     private static final String DUMMY_DOMAIN = "dummyDomain";
     private static final String DUMMY_RETRY_URL = "DummyRetryUrl";
     private static final String DUMMY_RETRY_URL_WITH_QUERY = "DummyRetryUrl?dummyQueryParams";
@@ -1434,7 +1435,7 @@ public class BasicAuthenticatorTestCase {
                 },
                 {
                         IdentityCoreConstants.ADMIN_FORCED_USER_PASSWORD_RESET_VIA_OTP_ERROR_CODE,
-                        "accountrecoveryendpoint/confirmrecovery.do?"
+                        DUMMY_RECOVERY_URL + "/confirmrecovery.do?"
                                 + BasicAuthenticatorConstants.USER_NAME_PARAM
                                 + URLEncoder.encode(DUMMY_USER_NAME, BasicAuthenticatorConstants.UTF_8)
                                 + BasicAuthenticatorConstants.TENANT_DOMAIN_PARAM
@@ -1446,7 +1447,7 @@ public class BasicAuthenticatorTestCase {
                 },
                 {
                         IdentityCoreConstants.ADMIN_FORCED_USER_PASSWORD_RESET_VIA_OTP_ERROR_CODE,
-                        "accountrecoveryendpoint/confirmrecovery.do?" +
+                        DUMMY_RECOVERY_URL + "/confirmrecovery.do?" +
                                 BasicAuthenticatorConstants.USER_NAME_PARAM +
                                 URLEncoder.encode(DUMMY_USER_NAME, BasicAuthenticatorConstants.UTF_8) +
                                 BasicAuthenticatorConstants.TENANT_DOMAIN_PARAM +
@@ -1524,6 +1525,7 @@ public class BasicAuthenticatorTestCase {
             configurationFacade.when(ConfigurationFacade::getInstance).thenReturn(mockConfigurationFacade);
             when(mockConfigurationFacade.getAuthenticationEndpointURL()).thenReturn(DUMMY_LOGIN_PAGEURL);
             when(mockConfigurationFacade.getAuthenticationEndpointRetryURL()).thenReturn(DUMMY_RETRY_URL);
+            when(mockConfigurationFacade.getAccountRecoveryEndpointPath()).thenReturn(DUMMY_RECOVERY_URL);
             when(mockAuthnCtxt.isRetrying()).thenReturn(true);
 
             when(mockIdentityErrorMsgContext.getErrorCode()).thenReturn(errorCode);


### PR DESCRIPTION
## Purpose
- $subject

### Related issues
- https://github.com/wso2/product-is/issues/23660

### Description
- In the previous url we only had the relative path which is not included the base url. Due to that when we redirecting it will use the api URL as the base path rather than the public url.
