### PR TITLE
Set IS_USER_RESOLVED property when ValidateUsername is enabled from adaptive script

### DIFF
--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
@@ -595,6 +595,8 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
                                         tenantAwareUsername, user.getTenantDomain());
                                 userId = user.getUserID();
                                 userStoreDomain = user.getUserStoreDomain();
+                                // Set a property to the context to indicate that the user is resolved from this step.
+                                setIsUserResolvedToContext(context);
                             }
                         } catch (OrganizationManagementException e) {
                             if (log.isDebugEnabled()) {
@@ -623,6 +625,8 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
                     if (StringUtils.isNotEmpty(userDetails[1])) {
                         userStoreDomain = userDetails[1];
                     }
+                    // Set a property to the context to indicate that the user is resolved from this step.
+                    setIsUserResolvedToContext(context);
                 }
 
                 // TODO: user tenant domain has to be an attribute in the AuthenticationContext.


### PR DESCRIPTION
In the Identifier First, when the `ValidateUsername` is configured as authenticator config, the user is resolved and the `isUserResolved` flag is correctly set in the authentication context. However, when ValidateUsername is set via an adaptive authentication script parameter, the user is still resolved, but isUserResolved is not set in the context.

This PR ensures that `isUserResolved` is correctly set in the context even when ValidateUsername is enabled through the adaptive authentication script.

Refer:
- https://github.com/wso2/product-is/issues/24154