### PR TITLE
Update to obtain captcha configurations from Captcha Config Service

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/pom.xml
@@ -180,6 +180,8 @@
                             org.wso2.carbon.utils; version="${carbon.kernel.imp.pkg.version.range}",
                             org.wso2.carbon.identity.captcha.connector.recaptcha; version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.captcha.util; version="${identity.governance.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.captcha.provider_mgt.service; version="${identity.governance.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.captcha.exception; version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.governance; version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.recovery; version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.recovery.util; version="${identity.governance.imp.pkg.version.range}",
@@ -269,6 +271,12 @@
                         </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <excludes>
+                        <exclude>org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorDataHolder.class</exclude>
+                        <exclude>org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorServiceComponent.class</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2014-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -1036,7 +1036,6 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                 Boolean.valueOf(properties.getProperty(CaptchaConstants.RE_CAPTCHA_ENABLED))) {
             if (StringUtils.isBlank(properties.getProperty(CaptchaConstants.RE_CAPTCHA_SITE_KEY)) ||
                     StringUtils.isBlank(properties.getProperty(CaptchaConstants.RE_CAPTCHA_API_URL)) ||
-                    StringUtils.isBlank(properties.getProperty(CaptchaConstants.RE_CAPTCHA_SECRET_KEY)) ||
                     StringUtils.isBlank(properties.getProperty(CaptchaConstants.RE_CAPTCHA_VERIFY_URL))) {
 
                 if (log.isDebugEnabled()) {

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorDataHolder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorDataHolder.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019-2025, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.application.authenticator.basicauth.internal;
 
+import org.wso2.carbon.identity.captcha.provider_mgt.service.CaptchaConfigService;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
@@ -35,6 +36,7 @@ public class BasicAuthenticatorDataHolder {
     private MultiAttributeLoginService multiAttributeLogin;
     private Properties recaptchaConfigs;
     private ConfigurationManager configurationManager = null;
+    private CaptchaConfigService captchaConfigService;
 
     private BasicAuthenticatorDataHolder() {
 
@@ -78,5 +80,14 @@ public class BasicAuthenticatorDataHolder {
     public ConfigurationManager getConfigurationManager() {
 
         return configurationManager;
+    }
+
+    public void setCaptchaConfigService(CaptchaConfigService captchaConfigService) {
+
+        this.captchaConfigService = captchaConfigService;
+    }
+
+    public CaptchaConfigService getCaptchaConfigService() {
+        return captchaConfigService;
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorServiceComponentTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/test/java/org/wso2/carbon/identity/application/authenticator/basicauth/internal/BasicAuthenticatorServiceComponentTestCase.java
@@ -17,14 +17,22 @@
  */
 package org.wso2.carbon.identity.application.authenticator.basicauth.internal;
 
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.osgi.service.component.ComponentContext;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.captcha.exception.CaptchaServerException;
+import org.wso2.carbon.identity.captcha.provider_mgt.service.CaptchaConfigService;
+import org.wso2.carbon.identity.captcha.provider_mgt.service.impl.CaptchaConfigServiceImpl;
 import org.wso2.carbon.identity.configuration.mgt.core.ConfigurationManager;
 import org.wso2.carbon.user.core.service.RealmService;
 
+import java.util.Properties;
+
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
@@ -65,10 +73,32 @@ public class BasicAuthenticatorServiceComponentTestCase {
 
     @Test
     public void activateTestCase() {
-        ComponentContext componentContext = mock(ComponentContext.class, Mockito.RETURNS_DEEP_STUBS);
-        basicAuthenticatorServiceComponent.activate(componentContext);
 
-        Mockito.verify(componentContext, Mockito.atLeastOnce()).getBundleContext();
+        ComponentContext componentContext = mock(ComponentContext.class, Mockito.RETURNS_DEEP_STUBS);
+        Properties captchaConfig = new Properties();
+        captchaConfig.setProperty("captchaEnabled", "true");
+        captchaConfig.setProperty("captchaProvider", "testCaptcha");
+        captchaConfig.setProperty("reCaptchaSiteKey", "testSiteKey");
+        captchaConfig.setProperty("reCaptchaSiteSecret", "testSiteSecret");
+
+        try (MockedStatic<BasicAuthenticatorDataHolder> mockedStatic =
+                     mockStatic(BasicAuthenticatorDataHolder.class)) {
+
+            BasicAuthenticatorDataHolder mockDataHolder = mock(BasicAuthenticatorDataHolder.class);
+
+            // Stub methods on the mock
+            CaptchaConfigService mockCaptchaConfigService = mock(CaptchaConfigService.class);
+            when(mockCaptchaConfigService.getActiveCaptchaProviderConfig()).thenReturn(
+                    captchaConfig); // or a real config if needed
+
+            when(mockDataHolder.getCaptchaConfigService()).thenReturn(mockCaptchaConfigService);
+
+            // Return mockDataHolder when getInstance() is called
+            mockedStatic.when(BasicAuthenticatorDataHolder::getInstance).thenReturn(mockDataHolder);
+            basicAuthenticatorServiceComponent.activate(componentContext);
+
+            Mockito.verify(componentContext, Mockito.atLeastOnce()).getBundleContext();
+        }
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -409,7 +409,7 @@
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
 
         <testng.version>6.9.10</testng.version>
-        <jacoco.version>0.8.6</jacoco.version>
+        <jacoco.version>0.8.12</jacoco.version>
         <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
         <org.slf4j.verison>1.6.1</org.slf4j.verison>
         <org.mockito.version>3.10.0</org.mockito.version>


### PR DESCRIPTION
### Purpose
This PR updates the approach of obtaining captcha configs in the basic authenticator from, reading the configs directly from the captcha.properties files to get them from the Captcha Config Service in the identity governance captcha module.

### Related Issues
- https://github.com/wso2/product-is/issues/23985

### Merge After
- https://github.com/wso2-extensions/identity-governance/pull/967