### PR TITLE
Fix issue in IDF to Basic Auth flow

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -722,8 +722,12 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
              * login page does not match. If the username submitted by login page is null, then the
              * username from the context will be considered as the username submitted from the login page.
              */
-             if (request.getParameter(USER_NAME) != null && usernameFromContext != null &&
-                    !usernameFromContext.equals(request.getParameter(USER_NAME))) {
+            String requestUsername = request.getParameter(USER_NAME);
+            String requestUsernameWithTenant =
+                    UserCoreUtil.addTenantDomainToEntry(requestUsername, requestTenantDomain);
+            if (requestUsername != null && usernameFromContext != null &&
+                    !usernameFromContext.equals(requestUsername) &&
+                    !usernameFromContext.equals(requestUsernameWithTenant)) {
                 if (log.isDebugEnabled()) {
                     log.debug("Username set for identifier first login: " + usernameFromContext + " and username " +
                             "submitted from login page" + username + " does not match.");


### PR DESCRIPTION
## Purpose
An error occurs in the app-native authn flow with the following steps.
Step1: identifier first
Step2: basic auth

Once the username for identifier first is filled and if the same username is provided, the authentication fails.

The error occurs due to the username in the request being validated against the username in the context.  The failure occurs due to the username in the context having the tenant domain appended while the username in the request does not have it.

## Approach
The fix is done with this PR where the tenant domain will be appended to the username in the request and then validated whether it is equal to the tenant domain in the context. 
