### PR TITLE
Append the recovery type as invite for the ask password OTP login flow

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -481,7 +481,8 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
                             BasicAuthenticatorConstants.UTF_8) + BasicAuthenticatorConstants.CALLBACK_PARAM +
                             URLEncoder.encode(callback, BasicAuthenticatorConstants.UTF_8) +
                             BasicAuthenticatorConstants.REASON_PARAM +
-                            URLEncoder.encode(reason, BasicAuthenticatorConstants.UTF_8);
+                            URLEncoder.encode(reason, BasicAuthenticatorConstants.UTF_8) +
+                            BasicAuthenticatorConstants.TYPE_PARAM + BasicAuthenticatorConstants.INVITE;
                     setAuthenticatorErrorMessage(getErrorMessage(errorCode, ASK_PASSWORD_VIA_OTP), context);
                 } else if (errorCode.equals(
                         IdentityCoreConstants.USER_ACCOUNT_PENDING_APPROVAL_ERROR_CODE)) {

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticatorConstants.java
@@ -54,6 +54,7 @@ public abstract class BasicAuthenticatorConstants {
     public static final String RECAPTCHA_API_PARAM = "&reCaptchaAPI=";
     public static final String CALLBACK_PARAM = "&callback=";
     public static final String REASON_PARAM = "&reason=";
+    public static final String TYPE_PARAM = "&type=";
 
     public static final String AUTHENTICATION_POLICY_CONFIG = "AuthenticationPolicy.CheckAccountExist";
 
@@ -82,6 +83,7 @@ public abstract class BasicAuthenticatorConstants {
     public static final String FORCED_PASSWORD_RESET_VIA_EMAIL = "The admin has forced user to " +
             "reset password via Email.";
     public static final String ASK_PASSWORD_VIA_OTP = "User is requested to set the password via OTP.";
+    public static final String INVITE = "invite";
 
     /**
      * Constants related to log management.


### PR DESCRIPTION
## Purpose
The password set up page and the password set up successful page contained password reset. With this fix after passing the recovery type as invitation, the portal shows the correct msg as shown below.

<img width="501" height="715" alt="Screenshot 2025-08-20 at 07 41 31" src="https://github.com/user-attachments/assets/533060b9-41f6-4170-b2ec-bed4c775ac42" />

<img width="466" height="510" alt="Screenshot 2025-08-20 at 07 41 43" src="https://github.com/user-attachments/assets/619be04e-499f-4683-a728-e9911ecb1ce3" />

### Related Issues
- https://github.com/wso2/product-is/issues/25243