### PR TITLE
Improve basic authenticator to handle shared user direct logins.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -750,6 +750,12 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
             requestTenantDomain = getTenantDomainFromUserName(context,
                     BasicAuthUtil.usePreprocessedUsername(context) ? username : loginIdentifierFromRequest);
         }
+        /*
+         * userTenantDomain is the tenant where the user resides and must be used for user-specific
+         * operations (e.g., resolving the user store). In B2B shared user direct login flows, this may differ from
+         * requestTenantDomain, which reflects the application's tenant and must be used for
+         * application-specific operations.
+         */
         String userTenantDomain = resolveUserTenantDomain(requestTenantDomain, context);
         String tenantAwareUsername = BasicAuthUtil.getTenantAwareUsername(context,
                 BasicAuthUtil.usePreprocessedUsername(context) ? username : loginIdentifierFromRequest);

--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -750,6 +750,7 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
             requestTenantDomain = getTenantDomainFromUserName(context,
                     BasicAuthUtil.usePreprocessedUsername(context) ? username : loginIdentifierFromRequest);
         }
+        String userTenantDomain = resolveUserTenantDomain(requestTenantDomain, context);
         String tenantAwareUsername = BasicAuthUtil.getTenantAwareUsername(context,
                 BasicAuthUtil.usePreprocessedUsername(context) ? username : loginIdentifierFromRequest);
         String userId = null;
@@ -812,7 +813,7 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
         authProperties.put(PASSWORD_PROPERTY, password);
 
         boolean isAuthenticated = false;
-        AbstractUserStoreManager userStoreManager = getUserStoreManager(username, requestTenantDomain);
+        AbstractUserStoreManager userStoreManager = getUserStoreManager(username, userTenantDomain);
         // Reset RE_CAPTCHA_USER_DOMAIN thread local variable before the authentication
         IdentityUtil.threadLocalProperties.get().remove(RE_CAPTCHA_USER_DOMAIN);
         // Check the authentication
@@ -1474,5 +1475,16 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
         log.warn("Tenant domain mismatch detected during authentication failure. User Tenant Domain: "
                 + userTenantDomain + ", Request Tenant Domain: " + contextTenantDomain + ", isSaasApp: "
                 + context.getSequenceConfig().getApplicationConfig().isSaaSApp());
+    }
+
+    private String resolveUserTenantDomain(String requestTenantDomain, AuthenticationContext context) {
+
+        if (Boolean.parseBoolean(IdentityUtil.getProperty(RESOLVE_TENANT_DOMAIN_FROM_USERNAME_CONFIG)) ||
+                !IdentityTenantUtil.isTenantQualifiedUrlsEnabled() ||
+                context.getSequenceConfig().getApplicationConfig().isSaaSApp()) {
+            return requestTenantDomain;
+        }
+
+        return context.getUserResidentTenantDomain();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -385,7 +385,7 @@
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.10.84</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.61</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.19.14, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -385,7 +385,7 @@
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.10.82</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.10.84</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.19.14, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
This pull request updates the logic for resolving the tenant domain used in user authentication and bumps the Carbon Identity Framework dependency version. The main change is the introduction of a new method to determine the correct tenant domain for user store operations.

Authentication tenant domain resolution improvements:

* Added a new `resolveUserTenantDomain` method in `BasicAuthenticator.java` to determine the user tenant domain based on configuration, SaaS app status, and tenant-qualified URL settings. This ensures the correct tenant domain is used for user store operations.
* Updated `processAuthenticationResponse` to use the resolved user tenant domain when retrieving the `UserStoreManager`, instead of the request tenant domain, supporting logins for instances where the user profile is managed at a different organization.

### Dependent on
- https://github.com/wso2/carbon-identity-framework/pull/7964
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3159

### Related issue
- https://github.com/wso2/product-is/issues/27371