### PR TITLE
Update user resident tenant domain resolution for shared users.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.basicauth/src/main/java/org/wso2/carbon/identity/application/authenticator/basicauth/BasicAuthenticator.java
@@ -1494,12 +1494,11 @@ public class BasicAuthenticator extends AbstractApplicationAuthenticator
 
     private String resolveUserTenantDomain(String requestTenantDomain, AuthenticationContext context) {
 
-        if (Boolean.parseBoolean(IdentityUtil.getProperty(RESOLVE_TENANT_DOMAIN_FROM_USERNAME_CONFIG)) ||
-                !IdentityTenantUtil.isTenantQualifiedUrlsEnabled() ||
-                context.getSequenceConfig().getApplicationConfig().isSaaSApp()) {
-            return requestTenantDomain;
+        Optional<AuthenticatedUser> sharedUser = FrameworkUtils.getSharedUserIdentifiedInSequence(context);
+        if (sharedUser.isPresent()) {
+            return context.getUserResidentTenantDomain();
         }
 
-        return context.getUserResidentTenantDomain();
+        return requestTenantDomain;
     }
 }


### PR DESCRIPTION
### Purpose

With previous logic, shared user resident tenant domain resolution was incorrect when the `RESOLVE_TENANT_DOMAIN_FROM_USERNAME_CONFIG`backward compatibility configuration is set to true. Removing this configuration from the `resolveUserTenantDomain` method will break the tenant domain resolution for the legacy behaviour. As an alternative, added a check for the shared user identified in the login sequence which is the only instance the user tenant domain will differ from the login tenant domain resolved earlier.


### Related issue
- https://github.com/wso2/product-is/issues/27371

  