### PR TITLE
Add user enumeration and account status controls to UserResolveExecutor

### DIFF
--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandlerConstants.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandlerConstants.java
@@ -18,8 +18,10 @@
 
 package org.wso2.carbon.identity.application.authentication.handler.identifier;
 
+import org.apache.commons.lang.StringUtils;
+
 /**
- * Constants used by the IdentifierHandler.
+ * Constants used by the IdentifierHandler
  */
 public abstract class IdentifierHandlerConstants {
 
@@ -91,7 +93,7 @@ public abstract class IdentifierHandlerConstants {
          */
         public static AccountLockedReason fromReason(String reason) {
 
-            if (reason == null || reason.trim().isEmpty()) {
+            if (reason == null || StringUtils.isBlank(reason)) {
                 return DEFAULT;
             }
             for (AccountLockedReason r : values()) {

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandlerConstants.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandlerConstants.java
@@ -19,7 +19,7 @@
 package org.wso2.carbon.identity.application.authentication.handler.identifier;
 
 /**
- * Constants used by the IdentifierHandler
+ * Constants used by the IdentifierHandler.
  */
 public abstract class IdentifierHandlerConstants {
 
@@ -35,7 +35,72 @@ public abstract class IdentifierHandlerConstants {
     public static final String USERNAME_USER_INPUT = "usernameUserInput";
     public static final String IS_USER_RESOLVED = "isUserResolved";
 
+    public static final String ACCOUNT_DISABLED = "The account is disabled.";
+    public static final String INVALID_IDENTIFIER = "The provided identifier is invalid.";
+
     private IdentifierHandlerConstants() {
+    }
+
+    /**
+     * Known account lock reasons with their associated i18n key and error message.
+     */
+    public enum AccountLockedReason {
+
+        DEFAULT("{{account.locked}}",
+                "The account is locked."),
+        MAX_ATTEMPTS_EXCEEDED("{{account.locked.max.attempts}}",
+                "The account is locked due to maximum failed login attempts."),
+        IDLE_ACCOUNT("{{account.locked.idle}}",
+                "The account is locked due to inactivity."),
+        PENDING_SELF_REGISTRATION("{{account.locked.pending.self.registration}}",
+                "The account is pending self-registration."),
+        PENDING_EMAIL_VERIFICATION("{{account.locked.pending.email.verification}}",
+                "The account is pending email verification."),
+        PENDING_ASK_PASSWORD("{{account.locked.pending.ask.password}}",
+                "The account is pending password setup."),
+        PENDING_ADMIN_FORCED_USER_PASSWORD_RESET("{{account.locked.pending.admin.forced.password.reset}}",
+                "The account is pending admin-forced password reset."),
+        ADMIN_INITIATED("{{account.locked.admin.initiated}}",
+                "The account has been locked by an administrator.");
+
+        private final String i18nKey;
+        private final String message;
+
+        AccountLockedReason(String i18nKey, String message) {
+
+            this.i18nKey = i18nKey;
+            this.message = message;
+        }
+
+        public String getI18nKey() {
+
+            return i18nKey;
+        }
+
+        public String getMessage() {
+
+            return message;
+        }
+
+        /**
+         * Returns the AccountLockedReason for the given reason string,
+         * or DEFAULT if the reason is null, blank, or unrecognized.
+         *
+         * @param reason Account locked reason string stored in the user's identity claims.
+         * @return Matching AccountLockedReason, or DEFAULT.
+         */
+        public static AccountLockedReason fromReason(String reason) {
+
+            if (reason == null || reason.trim().isEmpty()) {
+                return DEFAULT;
+            }
+            for (AccountLockedReason r : values()) {
+                if (r.name().equals(reason)) {
+                    return r;
+                }
+            }
+            return DEFAULT;
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandlerConstants.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandlerConstants.java
@@ -38,7 +38,9 @@ public abstract class IdentifierHandlerConstants {
     public static final String IS_USER_RESOLVED = "isUserResolved";
 
     public static final String ACCOUNT_DISABLED = "The account is disabled.";
+    public static final String ACCOUNT_DISABLED_I18N_KEY = "{{account.disabled}}";
     public static final String INVALID_IDENTIFIER = "The provided identifier is invalid.";
+    public static final String INVALID_IDENTIFIER_I18N_KEY = "{{invalid.identifier}}";
 
     private IdentifierHandlerConstants() {
     }

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
@@ -30,7 +30,7 @@ import org.wso2.carbon.identity.flow.execution.engine.graph.Executor;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.identity.flow.mgt.model.ExecutorDTO;
-import org.wso2.carbon.identity.flow.mgt.model.Message.MessageType;
+import org.wso2.carbon.identity.flow.mgt.model.MessageDTO.MessageType;
 import org.wso2.carbon.identity.flow.mgt.model.NodeConfig;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -152,14 +152,12 @@ public class UserResolveExecutor implements Executor {
                         IdentifierHandlerConstants.AccountLockedReason lockedReason =
                                 IdentifierHandlerConstants.AccountLockedReason.fromReason(reason);
                         executorResponse.setResult(STATUS_RETRY);
-                        executorResponse.setErrorMessage(lockedReason.getMessage());
                         executorResponse.addMessage(MessageType.ERROR, lockedReason.getMessage(),
                                 lockedReason.getI18nKey());
                         return executorResponse;
                     }
                     if (Boolean.parseBoolean((String) claimMap.get(FrameworkConstants.ACCOUNT_DISABLED_CLAIM_URI))) {
                         executorResponse.setResult(STATUS_RETRY);
-                        executorResponse.setErrorMessage(IdentifierHandlerConstants.ACCOUNT_DISABLED);
                         executorResponse.addMessage(MessageType.ERROR, IdentifierHandlerConstants.ACCOUNT_DISABLED,
                                 IdentifierHandlerConstants.ACCOUNT_DISABLED_I18N_KEY);
                         return executorResponse;
@@ -176,7 +174,6 @@ public class UserResolveExecutor implements Executor {
                 }
                 if (isNotifyUserExistenceEnabled(context)) {
                     executorResponse.setResult(STATUS_RETRY);
-                    executorResponse.setErrorMessage(IdentifierHandlerConstants.INVALID_IDENTIFIER);
                     executorResponse.addMessage(MessageType.ERROR, IdentifierHandlerConstants.INVALID_IDENTIFIER,
                             IdentifierHandlerConstants.INVALID_IDENTIFIER_I18N_KEY);
                     return executorResponse;

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
@@ -176,9 +176,8 @@ public class UserResolveExecutor implements Executor {
                     executorResponse.setI18nKey("{{invalid.identifier}}");
                     executorResponse.setErrorMessage(IdentifierHandlerConstants.INVALID_IDENTIFIER);
                     return executorResponse;
-                } else {
-                    executorResponse.setResult(STATUS_COMPLETE);
                 }
+                executorResponse.setResult(STATUS_COMPLETE);
             } else {
                 executorResponse.setResult(STATUS_ERROR);
                 executorResponse.setErrorMessage("Error while resolving user '" +

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.flow.execution.engine.graph.Executor;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.identity.flow.mgt.model.ExecutorDTO;
+import org.wso2.carbon.identity.flow.mgt.model.Message.MessageType;
 import org.wso2.carbon.identity.flow.mgt.model.NodeConfig;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -151,14 +152,16 @@ public class UserResolveExecutor implements Executor {
                         IdentifierHandlerConstants.AccountLockedReason lockedReason =
                                 IdentifierHandlerConstants.AccountLockedReason.fromReason(reason);
                         executorResponse.setResult(STATUS_RETRY);
-                        executorResponse.setI18nKey(lockedReason.getI18nKey());
                         executorResponse.setErrorMessage(lockedReason.getMessage());
+                        executorResponse.addMessage(MessageType.ERROR, lockedReason.getMessage(),
+                                lockedReason.getI18nKey());
                         return executorResponse;
                     }
                     if (Boolean.parseBoolean((String) claimMap.get(FrameworkConstants.ACCOUNT_DISABLED_CLAIM_URI))) {
                         executorResponse.setResult(STATUS_RETRY);
-                        executorResponse.setI18nKey("{{account.disabled}}");
                         executorResponse.setErrorMessage(IdentifierHandlerConstants.ACCOUNT_DISABLED);
+                        executorResponse.addMessage(MessageType.ERROR, IdentifierHandlerConstants.ACCOUNT_DISABLED,
+                                IdentifierHandlerConstants.ACCOUNT_DISABLED_I18N_KEY);
                         return executorResponse;
                     }
                 }
@@ -173,8 +176,9 @@ public class UserResolveExecutor implements Executor {
                 }
                 if (isNotifyUserExistenceEnabled(context)) {
                     executorResponse.setResult(STATUS_RETRY);
-                    executorResponse.setI18nKey("{{invalid.identifier}}");
                     executorResponse.setErrorMessage(IdentifierHandlerConstants.INVALID_IDENTIFIER);
+                    executorResponse.addMessage(MessageType.ERROR, IdentifierHandlerConstants.INVALID_IDENTIFIER,
+                            IdentifierHandlerConstants.INVALID_IDENTIFIER_I18N_KEY);
                     return executorResponse;
                 }
                 executorResponse.setResult(STATUS_COMPLETE);

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
@@ -152,7 +152,7 @@ public class UserResolveExecutor implements Executor {
                         String reason = context.getFlowUser().getAccountLockedReason();
                         executorResponse = new ExecutorResponse();
                         executorResponse.setResult(STATUS_RETRY);
-                        executorResponse.setErrorMessage(getAccountLockedMessageFromReason(reason));
+                        executorResponse.setErrorMessage(getAccountLockedReason(reason));
                         return executorResponse;
                     } else if (context.getFlowUser().isAccountDisabled()) {
                         executorResponse = new ExecutorResponse();
@@ -280,7 +280,7 @@ public class UserResolveExecutor implements Executor {
         return usernameClaim;
     }
 
-    private String getAccountLockedMessageFromReason(String reason) {
+    private String getAccountLockedReason(String reason) {
         if (StringUtils.isBlank(reason)) {
             return "{{password.reset.user.resolver.account.locked}}";
         }

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
@@ -129,11 +129,10 @@ public class UserResolveExecutor implements Executor {
      */
     private ExecutorResponse resolveUser(String username, String tenantDomain, FlowExecutionContext context) {
 
-        ExecutorResponse executorResponse;
+        ExecutorResponse executorResponse = new ExecutorResponse();
         try {
             UserRealm userRealm = getUserRealm(tenantDomain);
             if (userRealm == null) {
-                executorResponse = new ExecutorResponse();
                 executorResponse.setResult(STATUS_ERROR);
                 executorResponse.setErrorMessage("User realm is not available for tenant: " + tenantDomain);
                 return executorResponse;
@@ -143,27 +142,29 @@ public class UserResolveExecutor implements Executor {
             String resolvedUsername = resolveQualifiedUsername(username, userStoreManager, context);
             Claim[] claims = userStoreManager.getUserClaimValues(resolvedUsername, null);
             if (claims != null && claims.length > 0) {
-                Map<String, String> claimMap = Arrays.stream(claims)
+                Map<String, Object> claimMap = Arrays.stream(claims)
                         .filter(c -> c != null && c.getClaimUri() != null)
-                        .collect(Collectors.toMap(Claim::getClaimUri, Claim::getValue));
-                context.getFlowUser().addClaims(claimMap);
+                        .collect(Collectors.<Claim, String, Object>toMap(Claim::getClaimUri, Claim::getValue));
                 if (isNotifyUserAccountStatusEnabled(context)) {
-                    if (context.getFlowUser().isAccountLocked()) {
-                        String reason = context.getFlowUser().getAccountLockedReason();
-                        executorResponse = new ExecutorResponse();
+                    if (Boolean.parseBoolean((String) claimMap.get(FrameworkConstants.ACCOUNT_LOCKED_CLAIM_URI))) {
+                        String reason = (String) claimMap.get(FrameworkConstants.ACCOUNT_LOCKED_REASON_CLAIM_URI);
+                        IdentifierHandlerConstants.AccountLockedReason lockedReason =
+                                IdentifierHandlerConstants.AccountLockedReason.fromReason(reason);
                         executorResponse.setResult(STATUS_RETRY);
-                        executorResponse.setErrorMessage(getAccountLockedReason(reason));
+                        executorResponse.setI18nKey(lockedReason.getI18nKey());
+                        executorResponse.setErrorMessage(lockedReason.getMessage());
                         return executorResponse;
-                    } else if (context.getFlowUser().isAccountDisabled()) {
-                        executorResponse = new ExecutorResponse();
+                    }
+                    if (Boolean.parseBoolean((String) claimMap.get(FrameworkConstants.ACCOUNT_DISABLED_CLAIM_URI))) {
                         executorResponse.setResult(STATUS_RETRY);
-                        executorResponse.setErrorMessage("{{password.reset.user.resolver.account.disabled}}");
+                        executorResponse.setI18nKey("{{account.disabled}}");
+                        executorResponse.setErrorMessage(IdentifierHandlerConstants.ACCOUNT_DISABLED);
                         return executorResponse;
                     }
                 }
+                executorResponse.setUpdatedUserClaims(claimMap);
             }
-            executorResponse = new ExecutorResponse(STATUS_COMPLETE);
-
+            executorResponse.setResult(STATUS_COMPLETE);
         } catch (UserStoreException e) {
             if (e.getMessage().startsWith(String.valueOf(30007))) {
                 if (log.isDebugEnabled()) {
@@ -171,14 +172,14 @@ public class UserResolveExecutor implements Executor {
                             tenantDomain + "'.");
                 }
                 if (isNotifyUserExistenceEnabled(context)) {
-                    executorResponse = new ExecutorResponse();
                     executorResponse.setResult(STATUS_RETRY);
-                    executorResponse.setErrorMessage("{{password.reset.user.resolver.invalid.identifier}}");
+                    executorResponse.setI18nKey("{{invalid.identifier}}");
+                    executorResponse.setErrorMessage(IdentifierHandlerConstants.INVALID_IDENTIFIER);
+                    return executorResponse;
                 } else {
-                    executorResponse = new ExecutorResponse(STATUS_COMPLETE);
+                    executorResponse.setResult(STATUS_COMPLETE);
                 }
             } else {
-                executorResponse = new ExecutorResponse();
                 executorResponse.setResult(STATUS_ERROR);
                 executorResponse.setErrorMessage("Error while resolving user '" +
                         LoggerUtils.getMaskedContent(username) + "' in tenant '" + tenantDomain + "': " +
@@ -278,36 +279,6 @@ public class UserResolveExecutor implements Executor {
             usernameClaim = (String) context.getFlowUser().getClaim(FrameworkConstants.USERNAME_CLAIM);
         }
         return usernameClaim;
-    }
-
-    /**
-     * Returns the i18n message key corresponding to the account lock reason.
-     * If the reason is blank or unrecognized, the generic locked message key is returned.
-     *
-     * @param reason Account locked reason string stored in the user's identity claims.
-     * @return i18n message key to surface to the user.
-     */
-    private String getAccountLockedReason(String reason) {
-        if (StringUtils.isBlank(reason)) {
-            return "{{password.reset.user.resolver.account.locked}}";
-        }
-        switch (reason) {
-            case "MAX_ATTEMPTS_EXCEEDED":
-                return "{{password.reset.user.resolver.account.locked.max.attempts}}";
-            case "IDLE_ACCOUNT":
-                return "{{password.reset.user.resolver.account.locked.idle}}";
-            case "PENDING_SELF_REGISTRATION":
-                return "{{password.reset.user.resolver.account.locked.pending.self.registration}}";
-            case "PENDING_EMAIL_VERIFICATION":
-                return "{{password.reset.user.resolver.account.locked.pending.email.verification}}";
-            case "PENDING_ASK_PASSWORD":
-                return "{{password.reset.user.resolver.account.locked.pending.ask.password}}";
-            case "PENDING_ADMIN_FORCED_USER_PASSWORD_RESET":
-                return "{{password.reset.user.resolver.account.locked.pending.admin.forced.password.reset}}";
-            case "ADMIN_INITIATED":
-            default:
-                return "{{password.reset.user.resolver.account.locked}}";
-        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
@@ -280,6 +280,13 @@ public class UserResolveExecutor implements Executor {
         return usernameClaim;
     }
 
+    /**
+     * Returns the i18n message key corresponding to the account lock reason.
+     * If the reason is blank or unrecognized, the generic locked message key is returned.
+     *
+     * @param reason Account locked reason string stored in the user's identity claims.
+     * @return i18n message key to surface to the user.
+     */
     private String getAccountLockedReason(String reason) {
         if (StringUtils.isBlank(reason)) {
             return "{{password.reset.user.resolver.account.locked}}";
@@ -303,21 +310,43 @@ public class UserResolveExecutor implements Executor {
         }
     }
 
+    /**
+     * Checks whether the notifyUserExistence flag is enabled in the executor metadata.
+     *
+     * @param context Flow execution context.
+     * @return True if the flag is enabled, false otherwise.
+     */
     private boolean isNotifyUserExistenceEnabled(FlowExecutionContext context) {
-        NodeConfig currentNode = context.getCurrentNode();
-        ExecutorDTO executorConfig = currentNode.getExecutorConfig();
-        if (executorConfig == null || executorConfig.getMetadata() == null) {
-            return false;
-        }
-        return Boolean.parseBoolean(executorConfig.getMetadata().get(NOTIFY_USER_EXISTENCE));
+        return isExecutorMetadataFlagEnabled(context, NOTIFY_USER_EXISTENCE);
     }
 
+    /**
+     * Checks whether the notifyUserAccountStatus flag is enabled in the executor metadata.
+     *
+     * @param context Flow execution context.
+     * @return True if the flag is enabled, false otherwise.
+     */
     private boolean isNotifyUserAccountStatusEnabled(FlowExecutionContext context) {
+        return isExecutorMetadataFlagEnabled(context, NOTIFY_USER_ACCOUNT_STATUS);
+    }
+
+    /**
+     * Reads a boolean flag from the current node's executor metadata.
+     * Returns false safely if the node, executor config, or metadata map is absent.
+     *
+     * @param context     Flow execution context.
+     * @param metadataKey Metadata key to look up.
+     * @return True if the metadata value parses to true, false if absent or unparseable.
+     */
+    private boolean isExecutorMetadataFlagEnabled(FlowExecutionContext context, String metadataKey) {
         NodeConfig currentNode = context.getCurrentNode();
+        if (currentNode == null) {
+            return false;
+        }
         ExecutorDTO executorConfig = currentNode.getExecutorConfig();
         if (executorConfig == null || executorConfig.getMetadata() == null) {
             return false;
         }
-        return Boolean.parseBoolean(executorConfig.getMetadata().get(NOTIFY_USER_ACCOUNT_STATUS));
+        return Boolean.parseBoolean(executorConfig.getMetadata().get(metadataKey));
     }
 }

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
@@ -182,8 +182,7 @@ public class UserResolveExecutor implements Executor {
             } else {
                 executorResponse.setResult(STATUS_ERROR);
                 executorResponse.setErrorMessage("Error while resolving user '" +
-                        LoggerUtils.getMaskedContent(username) + "' in tenant '" + tenantDomain + "': " +
-                        e.getMessage());
+                        LoggerUtils.getMaskedContent(username) + "' in tenant '" + tenantDomain + "': " + e.getMessage());
             }
         }
         return executorResponse;
@@ -288,6 +287,7 @@ public class UserResolveExecutor implements Executor {
      * @return True if the flag is enabled, false otherwise.
      */
     private boolean isNotifyUserExistenceEnabled(FlowExecutionContext context) {
+
         return isExecutorMetadataFlagEnabled(context, NOTIFY_USER_EXISTENCE);
     }
 
@@ -298,6 +298,7 @@ public class UserResolveExecutor implements Executor {
      * @return True if the flag is enabled, false otherwise.
      */
     private boolean isNotifyUserAccountStatusEnabled(FlowExecutionContext context) {
+
         return isExecutorMetadataFlagEnabled(context, NOTIFY_USER_ACCOUNT_STATUS);
     }
 
@@ -310,6 +311,7 @@ public class UserResolveExecutor implements Executor {
      * @return True if the metadata value parses to true, false if absent or unparseable.
      */
     private boolean isExecutorMetadataFlagEnabled(FlowExecutionContext context, String metadataKey) {
+
         NodeConfig currentNode = context.getCurrentNode();
         if (currentNode == null) {
             return false;

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
@@ -18,9 +18,6 @@
 
 package org.wso2.carbon.identity.application.authentication.handler.identifier;
 
-import java.util.Arrays;
-import java.util.Map;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -32,21 +29,26 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.flow.execution.engine.graph.Executor;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
+import org.wso2.carbon.identity.flow.mgt.model.ExecutorDTO;
+import org.wso2.carbon.identity.flow.mgt.model.NodeConfig;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
+import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
-import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.claim.Claim;
 import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_ERROR;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_USER_INPUT_REQUIRED;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_COMPLETE;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_RETRY;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.USERNAME_CLAIM_URI;
 
 /**
@@ -58,6 +60,8 @@ public class UserResolveExecutor implements Executor {
     public static final String USER_IDENTIFIER = "userIdentifier";
     private static final Log log = LogFactory.getLog(UserResolveExecutor.class);
     public static final String FLOW_EXECUTION_USER_STORE_DOMAIN = "FlowExecution.ExcludedUserstores.Userstore";
+    private static final String NOTIFY_USER_EXISTENCE = "notifyUserExistence";
+    private static final String NOTIFY_USER_ACCOUNT_STATUS = "notifyUserAccountStatus";
 
     /**
      * Returns the name of the executor.
@@ -143,6 +147,20 @@ public class UserResolveExecutor implements Executor {
                         .filter(c -> c != null && c.getClaimUri() != null)
                         .collect(Collectors.toMap(Claim::getClaimUri, Claim::getValue));
                 context.getFlowUser().addClaims(claimMap);
+                if (isNotifyUserAccountStatusEnabled(context)) {
+                    if (context.getFlowUser().isAccountLocked()) {
+                        String reason = context.getFlowUser().getAccountLockedReason();
+                        executorResponse = new ExecutorResponse();
+                        executorResponse.setResult(STATUS_RETRY);
+                        executorResponse.setErrorMessage(getAccountLockedMessageFromReason(reason));
+                        return executorResponse;
+                    } else if (context.getFlowUser().isAccountDisabled()) {
+                        executorResponse = new ExecutorResponse();
+                        executorResponse.setResult(STATUS_RETRY);
+                        executorResponse.setErrorMessage("{{password.reset.user.resolver.account.disabled}}");
+                        return executorResponse;
+                    }
+                }
             }
             executorResponse = new ExecutorResponse(STATUS_COMPLETE);
 
@@ -152,12 +170,19 @@ public class UserResolveExecutor implements Executor {
                     log.debug("User '" + LoggerUtils.getMaskedContent(username) + "' does not exist in tenant '" +
                             tenantDomain + "'.");
                 }
-                executorResponse = new ExecutorResponse(STATUS_COMPLETE);
+                if (isNotifyUserExistenceEnabled(context)) {
+                    executorResponse = new ExecutorResponse();
+                    executorResponse.setResult(STATUS_RETRY);
+                    executorResponse.setErrorMessage("{{password.reset.user.resolver.invalid.identifier}}");
+                } else {
+                    executorResponse = new ExecutorResponse(STATUS_COMPLETE);
+                }
             } else {
                 executorResponse = new ExecutorResponse();
                 executorResponse.setResult(STATUS_ERROR);
                 executorResponse.setErrorMessage("Error while resolving user '" +
-                        LoggerUtils.getMaskedContent(username) + "' in tenant '" + tenantDomain + "': " + e.getMessage());
+                        LoggerUtils.getMaskedContent(username) + "' in tenant '" + tenantDomain + "': " +
+                        e.getMessage());
             }
         }
         return executorResponse;
@@ -253,5 +278,46 @@ public class UserResolveExecutor implements Executor {
             usernameClaim = (String) context.getFlowUser().getClaim(FrameworkConstants.USERNAME_CLAIM);
         }
         return usernameClaim;
+    }
+
+    private String getAccountLockedMessageFromReason(String reason) {
+        if (StringUtils.isBlank(reason)) {
+            return "{{password.reset.user.resolver.account.locked}}";
+        }
+        switch (reason) {
+            case "MAX_ATTEMPTS_EXCEEDED":
+                return "{{password.reset.user.resolver.account.locked.max.attempts}}";
+            case "IDLE_ACCOUNT":
+                return "{{password.reset.user.resolver.account.locked.idle}}";
+            case "PENDING_SELF_REGISTRATION":
+                return "{{password.reset.user.resolver.account.locked.pending.self.registration}}";
+            case "PENDING_EMAIL_VERIFICATION":
+                return "{{password.reset.user.resolver.account.locked.pending.email.verification}}";
+            case "PENDING_ASK_PASSWORD":
+                return "{{password.reset.user.resolver.account.locked.pending.ask.password}}";
+            case "PENDING_ADMIN_FORCED_USER_PASSWORD_RESET":
+                return "{{password.reset.user.resolver.account.locked.pending.admin.forced.password.reset}}";
+            case "ADMIN_INITIATED":
+            default:
+                return "{{password.reset.user.resolver.account.locked}}";
+        }
+    }
+
+    private boolean isNotifyUserExistenceEnabled(FlowExecutionContext context) {
+        NodeConfig currentNode = context.getCurrentNode();
+        ExecutorDTO executorConfig = currentNode.getExecutorConfig();
+        if (executorConfig == null || executorConfig.getMetadata() == null) {
+            return false;
+        }
+        return Boolean.parseBoolean(executorConfig.getMetadata().get(NOTIFY_USER_EXISTENCE));
+    }
+
+    private boolean isNotifyUserAccountStatusEnabled(FlowExecutionContext context) {
+        NodeConfig currentNode = context.getCurrentNode();
+        ExecutorDTO executorConfig = currentNode.getExecutorConfig();
+        if (executorConfig == null || executorConfig.getMetadata() == null) {
+            return false;
+        }
+        return Boolean.parseBoolean(executorConfig.getMetadata().get(NOTIFY_USER_ACCOUNT_STATUS));
     }
 }

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/test/java/org/wso2/carbon/identity/application/authenticator/handler/identifier/UserResolveExecutorTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/test/java/org/wso2/carbon/identity/application/authenticator/handler/identifier/UserResolveExecutorTestCase.java
@@ -15,8 +15,8 @@ import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
 import org.wso2.carbon.identity.flow.mgt.model.ExecutorDTO;
-import org.wso2.carbon.identity.flow.mgt.model.Message;
-import org.wso2.carbon.identity.flow.mgt.model.Message.MessageType;
+import org.wso2.carbon.identity.flow.mgt.model.MessageDTO;
+import org.wso2.carbon.identity.flow.mgt.model.MessageDTO.MessageType;
 import org.wso2.carbon.identity.flow.mgt.model.NodeConfig;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.user.core.UserCoreConstants;
@@ -315,7 +315,6 @@ public class UserResolveExecutorTestCase {
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_RETRY);
-        Assert.assertEquals(response.getErrorMessage(), "The provided identifier is invalid.");
         assertSingleErrorMessage(response, "The provided identifier is invalid.", "{{invalid.identifier}}");
     }
 
@@ -356,7 +355,6 @@ public class UserResolveExecutorTestCase {
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_RETRY);
-        Assert.assertEquals(response.getErrorMessage(), "The account is locked.");
         assertSingleErrorMessage(response, "The account is locked.", "{{account.locked}}");
     }
 
@@ -371,8 +369,6 @@ public class UserResolveExecutorTestCase {
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_RETRY);
-        Assert.assertEquals(response.getErrorMessage(),
-                "The account is locked due to maximum failed login attempts.");
         assertSingleErrorMessage(response, "The account is locked due to maximum failed login attempts.",
                 "{{account.locked.max.attempts}}");
     }
@@ -388,7 +384,6 @@ public class UserResolveExecutorTestCase {
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_RETRY);
-        Assert.assertEquals(response.getErrorMessage(), "The account has been locked by an administrator.");
         assertSingleErrorMessage(response, "The account has been locked by an administrator.",
                 "{{account.locked.admin.initiated}}");
     }
@@ -402,7 +397,6 @@ public class UserResolveExecutorTestCase {
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_RETRY);
-        Assert.assertEquals(response.getErrorMessage(), "The account is disabled.");
         assertSingleErrorMessage(response, "The account is disabled.", "{{account.disabled}}");
     }
 
@@ -455,7 +449,7 @@ public class UserResolveExecutorTestCase {
 
         Assert.assertNotNull(response.getMessages());
         Assert.assertEquals(response.getMessages().size(), 1);
-        Message message = response.getMessages().get(0);
+        MessageDTO message = response.getMessages().get(0);
         Assert.assertEquals(message.getType(), MessageType.ERROR);
         Assert.assertEquals(message.getMessage(), expectedMessage);
         Assert.assertEquals(message.getI18nKey(), expectedI18nKey);

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/test/java/org/wso2/carbon/identity/application/authenticator/handler/identifier/UserResolveExecutorTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/test/java/org/wso2/carbon/identity/application/authenticator/handler/identifier/UserResolveExecutorTestCase.java
@@ -300,7 +300,7 @@ public class UserResolveExecutorTestCase {
         field.set(null, null);
     }
 
-    // ---- notifyUserExistence tests ----
+    // Tests for notifying user existence.
 
     @Test
     public void testUserNotFound_withNotifyUserExistenceEnabled() throws Exception {
@@ -343,7 +343,7 @@ public class UserResolveExecutorTestCase {
         Assert.assertEquals(response.getResult(), STATUS_COMPLETE);
     }
 
-    // ---- notifyUserAccountStatus tests ----
+    // Tests for notifying user account status.
 
     @Test
     public void testAccountLocked_withNotifyAccountStatusEnabled() throws Exception {
@@ -424,7 +424,7 @@ public class UserResolveExecutorTestCase {
         Assert.assertEquals(response.getResult(), STATUS_COMPLETE);
     }
 
-    // ---- Helpers ----
+    // Helper methods.
 
     private void setupExecutorMetadata(String key, String value) {
 

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/test/java/org/wso2/carbon/identity/application/authenticator/handler/identifier/UserResolveExecutorTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/test/java/org/wso2/carbon/identity/application/authenticator/handler/identifier/UserResolveExecutorTestCase.java
@@ -15,6 +15,8 @@ import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
 import org.wso2.carbon.identity.flow.mgt.model.ExecutorDTO;
+import org.wso2.carbon.identity.flow.mgt.model.Message;
+import org.wso2.carbon.identity.flow.mgt.model.Message.MessageType;
 import org.wso2.carbon.identity.flow.mgt.model.NodeConfig;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.user.core.UserCoreConstants;
@@ -313,8 +315,8 @@ public class UserResolveExecutorTestCase {
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_RETRY);
-        Assert.assertEquals(response.getI18nKey(), "{{invalid.identifier}}");
         Assert.assertEquals(response.getErrorMessage(), "The provided identifier is invalid.");
+        assertSingleErrorMessage(response, "The provided identifier is invalid.", "{{invalid.identifier}}");
     }
 
     @Test
@@ -354,8 +356,8 @@ public class UserResolveExecutorTestCase {
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_RETRY);
-        Assert.assertEquals(response.getI18nKey(), "{{account.locked}}");
         Assert.assertEquals(response.getErrorMessage(), "The account is locked.");
+        assertSingleErrorMessage(response, "The account is locked.", "{{account.locked}}");
     }
 
     @Test
@@ -369,9 +371,10 @@ public class UserResolveExecutorTestCase {
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_RETRY);
-        Assert.assertEquals(response.getI18nKey(), "{{account.locked.max.attempts}}");
         Assert.assertEquals(response.getErrorMessage(),
                 "The account is locked due to maximum failed login attempts.");
+        assertSingleErrorMessage(response, "The account is locked due to maximum failed login attempts.",
+                "{{account.locked.max.attempts}}");
     }
 
     @Test
@@ -385,8 +388,9 @@ public class UserResolveExecutorTestCase {
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_RETRY);
-        Assert.assertEquals(response.getI18nKey(), "{{account.locked.admin.initiated}}");
         Assert.assertEquals(response.getErrorMessage(), "The account has been locked by an administrator.");
+        assertSingleErrorMessage(response, "The account has been locked by an administrator.",
+                "{{account.locked.admin.initiated}}");
     }
 
     @Test
@@ -398,8 +402,8 @@ public class UserResolveExecutorTestCase {
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_RETRY);
-        Assert.assertEquals(response.getI18nKey(), "{{account.disabled}}");
         Assert.assertEquals(response.getErrorMessage(), "The account is disabled.");
+        assertSingleErrorMessage(response, "The account is disabled.", "{{account.disabled}}");
     }
 
     @Test
@@ -445,6 +449,16 @@ public class UserResolveExecutorTestCase {
         System.arraycopy(additionalClaims, 0, allClaims, 1, additionalClaims.length);
         when(mockUserStoreManager.getUserClaimValues(TEST_DOMAIN_QUALIFIED_USERNAME, null))
                 .thenReturn(allClaims);
+    }
+
+    private void assertSingleErrorMessage(ExecutorResponse response, String expectedMessage, String expectedI18nKey) {
+
+        Assert.assertNotNull(response.getMessages());
+        Assert.assertEquals(response.getMessages().size(), 1);
+        Message message = response.getMessages().get(0);
+        Assert.assertEquals(message.getType(), MessageType.ERROR);
+        Assert.assertEquals(message.getMessage(), expectedMessage);
+        Assert.assertEquals(message.getI18nKey(), expectedI18nKey);
     }
 
     private Claim buildClaim(String uri, String value) {

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/test/java/org/wso2/carbon/identity/application/authenticator/handler/identifier/UserResolveExecutorTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/test/java/org/wso2/carbon/identity/application/authenticator/handler/identifier/UserResolveExecutorTestCase.java
@@ -14,6 +14,8 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.flow.execution.engine.model.ExecutorResponse;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowExecutionContext;
 import org.wso2.carbon.identity.flow.execution.engine.model.FlowUser;
+import org.wso2.carbon.identity.flow.mgt.model.ExecutorDTO;
+import org.wso2.carbon.identity.flow.mgt.model.NodeConfig;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
@@ -37,6 +39,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_COMPLETE;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_ERROR;
+import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_RETRY;
 import static org.wso2.carbon.identity.flow.execution.engine.Constants.ExecutorStatus.STATUS_USER_INPUT_REQUIRED;
 
 public class UserResolveExecutorTestCase {
@@ -73,6 +76,12 @@ public class UserResolveExecutorTestCase {
 
     @Mock
     private MultiAttributeLoginService mockMultiAttributeLoginService;
+
+    @Mock
+    private NodeConfig mockNodeConfig;
+
+    @Mock
+    private ExecutorDTO mockExecutorDTO;
 
     private UserResolveExecutor userResolveExecutor;
     private final Map<String, Object> userClaims = new HashMap<>();
@@ -287,5 +296,153 @@ public class UserResolveExecutorTestCase {
         Field field = IdentifierAuthenticatorServiceComponent.class.getDeclaredField("multiAttributeLogin");
         field.setAccessible(true);
         field.set(null, null);
+    }
+
+    // ---- notifyUserExistence tests ----
+
+    @Test
+    public void testUserNotFound_withNotifyUserExistenceEnabled() throws Exception {
+
+        when(mockFlowUser.getClaim(FrameworkConstants.USERNAME_CLAIM)).thenReturn(TEST_USERNAME);
+        when(mockUserStoreManager.isExistingUser(anyString()))
+                .thenThrow(new UserStoreException("30007 - User does not exist"));
+        setupExecutorMetadata("notifyUserExistence", "true");
+
+        ExecutorResponse response = userResolveExecutor.execute(mockContext);
+
+        Assert.assertEquals(response.getResult(), STATUS_RETRY);
+        Assert.assertEquals(response.getErrorMessage(), "{{password.reset.user.resolver.invalid.identifier}}");
+    }
+
+    @Test
+    public void testUserNotFound_withNotifyUserExistenceDisabled() throws Exception {
+
+        when(mockFlowUser.getClaim(FrameworkConstants.USERNAME_CLAIM)).thenReturn(TEST_USERNAME);
+        when(mockUserStoreManager.isExistingUser(anyString()))
+                .thenThrow(new UserStoreException("30007 - User does not exist"));
+        setupExecutorMetadata("notifyUserExistence", "false");
+
+        ExecutorResponse response = userResolveExecutor.execute(mockContext);
+
+        Assert.assertEquals(response.getResult(), STATUS_COMPLETE);
+    }
+
+    @Test
+    public void testUserNotFound_withNullCurrentNode() throws Exception {
+
+        when(mockFlowUser.getClaim(FrameworkConstants.USERNAME_CLAIM)).thenReturn(TEST_USERNAME);
+        when(mockUserStoreManager.isExistingUser(anyString()))
+                .thenThrow(new UserStoreException("30007 - User does not exist"));
+        when(mockContext.getCurrentNode()).thenReturn(null);
+
+        ExecutorResponse response = userResolveExecutor.execute(mockContext);
+
+        Assert.assertEquals(response.getResult(), STATUS_COMPLETE);
+    }
+
+    // ---- notifyUserAccountStatus tests ----
+
+    @Test
+    public void testAccountLocked_withNotifyAccountStatusEnabled() throws Exception {
+
+        setupUserWithClaims();
+        setupExecutorMetadata("notifyUserAccountStatus", "true");
+        when(mockFlowUser.isAccountLocked()).thenReturn(true);
+        when(mockFlowUser.getAccountLockedReason()).thenReturn(null);
+
+        ExecutorResponse response = userResolveExecutor.execute(mockContext);
+
+        Assert.assertEquals(response.getResult(), STATUS_RETRY);
+        Assert.assertEquals(response.getErrorMessage(), "{{password.reset.user.resolver.account.locked}}");
+    }
+
+    @Test
+    public void testAccountLocked_withMaxAttemptsExceededReason() throws Exception {
+
+        setupUserWithClaims();
+        setupExecutorMetadata("notifyUserAccountStatus", "true");
+        when(mockFlowUser.isAccountLocked()).thenReturn(true);
+        when(mockFlowUser.getAccountLockedReason()).thenReturn("MAX_ATTEMPTS_EXCEEDED");
+
+        ExecutorResponse response = userResolveExecutor.execute(mockContext);
+
+        Assert.assertEquals(response.getResult(), STATUS_RETRY);
+        Assert.assertEquals(response.getErrorMessage(),
+                "{{password.reset.user.resolver.account.locked.max.attempts}}");
+    }
+
+    @Test
+    public void testAccountLocked_withAdminInitiatedReason() throws Exception {
+
+        setupUserWithClaims();
+        setupExecutorMetadata("notifyUserAccountStatus", "true");
+        when(mockFlowUser.isAccountLocked()).thenReturn(true);
+        when(mockFlowUser.getAccountLockedReason()).thenReturn("ADMIN_INITIATED");
+
+        ExecutorResponse response = userResolveExecutor.execute(mockContext);
+
+        Assert.assertEquals(response.getResult(), STATUS_RETRY);
+        Assert.assertEquals(response.getErrorMessage(), "{{password.reset.user.resolver.account.locked}}");
+    }
+
+    @Test
+    public void testAccountDisabled_withNotifyAccountStatusEnabled() throws Exception {
+
+        setupUserWithClaims();
+        setupExecutorMetadata("notifyUserAccountStatus", "true");
+        when(mockFlowUser.isAccountLocked()).thenReturn(false);
+        when(mockFlowUser.isAccountDisabled()).thenReturn(true);
+
+        ExecutorResponse response = userResolveExecutor.execute(mockContext);
+
+        Assert.assertEquals(response.getResult(), STATUS_RETRY);
+        Assert.assertEquals(response.getErrorMessage(),
+                "{{password.reset.user.resolver.account.disabled}}");
+    }
+
+    @Test
+    public void testAccountLocked_withNotifyAccountStatusDisabled() throws Exception {
+
+        setupUserWithClaims();
+        setupExecutorMetadata("notifyUserAccountStatus", "false");
+        when(mockFlowUser.isAccountLocked()).thenReturn(true);
+
+        ExecutorResponse response = userResolveExecutor.execute(mockContext);
+
+        Assert.assertEquals(response.getResult(), STATUS_COMPLETE);
+    }
+
+    @Test
+    public void testAccountStatus_withNullCurrentNode() throws Exception {
+
+        setupUserWithClaims();
+        when(mockContext.getCurrentNode()).thenReturn(null);
+        when(mockFlowUser.isAccountLocked()).thenReturn(true);
+
+        ExecutorResponse response = userResolveExecutor.execute(mockContext);
+
+        Assert.assertEquals(response.getResult(), STATUS_COMPLETE);
+    }
+
+    // ---- Helpers ----
+
+    private void setupExecutorMetadata(String key, String value) {
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put(key, value);
+        when(mockContext.getCurrentNode()).thenReturn(mockNodeConfig);
+        when(mockNodeConfig.getExecutorConfig()).thenReturn(mockExecutorDTO);
+        when(mockExecutorDTO.getMetadata()).thenReturn(metadata);
+    }
+
+    private void setupUserWithClaims() throws Exception {
+
+        when(mockFlowUser.getClaim(FrameworkConstants.USERNAME_CLAIM)).thenReturn(TEST_USERNAME);
+        when(mockUserStoreManager.isExistingUser(TEST_DOMAIN_QUALIFIED_USERNAME)).thenReturn(true);
+        Claim emailClaim = new Claim();
+        emailClaim.setClaimUri("http://wso2.org/claims/emailaddress");
+        emailClaim.setValue("test@example.com");
+        when(mockUserStoreManager.getUserClaimValues(TEST_DOMAIN_QUALIFIED_USERNAME, null))
+                .thenReturn(new Claim[]{emailClaim});
     }
 }

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/test/java/org/wso2/carbon/identity/application/authenticator/handler/identifier/UserResolveExecutorTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/test/java/org/wso2/carbon/identity/application/authenticator/handler/identifier/UserResolveExecutorTestCase.java
@@ -177,7 +177,9 @@ public class UserResolveExecutorTestCase {
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_COMPLETE);
-        verify(mockFlowUser).addClaims(any());
+        Assert.assertNotNull(response.getUpdatedUserClaims());
+        Assert.assertEquals(response.getUpdatedUserClaims().get("http://wso2.org/claims/emailaddress"), "test@example.com");
+        Assert.assertEquals(response.getUpdatedUserClaims().get("http://wso2.org/claims/givenname"), "Test User");
     }
 
     @Test
@@ -311,7 +313,8 @@ public class UserResolveExecutorTestCase {
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_RETRY);
-        Assert.assertEquals(response.getErrorMessage(), "{{password.reset.user.resolver.invalid.identifier}}");
+        Assert.assertEquals(response.getI18nKey(), "{{invalid.identifier}}");
+        Assert.assertEquals(response.getErrorMessage(), "The provided identifier is invalid.");
     }
 
     @Test
@@ -345,67 +348,65 @@ public class UserResolveExecutorTestCase {
     @Test
     public void testAccountLocked_withNotifyAccountStatusEnabled() throws Exception {
 
-        setupUserWithClaims();
+        setupUserWithClaims(buildClaim(FrameworkConstants.ACCOUNT_LOCKED_CLAIM_URI, "true"));
         setupExecutorMetadata("notifyUserAccountStatus", "true");
-        when(mockFlowUser.isAccountLocked()).thenReturn(true);
-        when(mockFlowUser.getAccountLockedReason()).thenReturn(null);
 
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_RETRY);
-        Assert.assertEquals(response.getErrorMessage(), "{{password.reset.user.resolver.account.locked}}");
+        Assert.assertEquals(response.getI18nKey(), "{{account.locked}}");
+        Assert.assertEquals(response.getErrorMessage(), "The account is locked.");
     }
 
     @Test
     public void testAccountLocked_withMaxAttemptsExceededReason() throws Exception {
 
-        setupUserWithClaims();
+        setupUserWithClaims(
+                buildClaim(FrameworkConstants.ACCOUNT_LOCKED_CLAIM_URI, "true"),
+                buildClaim(FrameworkConstants.ACCOUNT_LOCKED_REASON_CLAIM_URI, "MAX_ATTEMPTS_EXCEEDED"));
         setupExecutorMetadata("notifyUserAccountStatus", "true");
-        when(mockFlowUser.isAccountLocked()).thenReturn(true);
-        when(mockFlowUser.getAccountLockedReason()).thenReturn("MAX_ATTEMPTS_EXCEEDED");
 
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_RETRY);
+        Assert.assertEquals(response.getI18nKey(), "{{account.locked.max.attempts}}");
         Assert.assertEquals(response.getErrorMessage(),
-                "{{password.reset.user.resolver.account.locked.max.attempts}}");
+                "The account is locked due to maximum failed login attempts.");
     }
 
     @Test
     public void testAccountLocked_withAdminInitiatedReason() throws Exception {
 
-        setupUserWithClaims();
+        setupUserWithClaims(
+                buildClaim(FrameworkConstants.ACCOUNT_LOCKED_CLAIM_URI, "true"),
+                buildClaim(FrameworkConstants.ACCOUNT_LOCKED_REASON_CLAIM_URI, "ADMIN_INITIATED"));
         setupExecutorMetadata("notifyUserAccountStatus", "true");
-        when(mockFlowUser.isAccountLocked()).thenReturn(true);
-        when(mockFlowUser.getAccountLockedReason()).thenReturn("ADMIN_INITIATED");
 
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_RETRY);
-        Assert.assertEquals(response.getErrorMessage(), "{{password.reset.user.resolver.account.locked}}");
+        Assert.assertEquals(response.getI18nKey(), "{{account.locked.admin.initiated}}");
+        Assert.assertEquals(response.getErrorMessage(), "The account has been locked by an administrator.");
     }
 
     @Test
     public void testAccountDisabled_withNotifyAccountStatusEnabled() throws Exception {
 
-        setupUserWithClaims();
+        setupUserWithClaims(buildClaim(FrameworkConstants.ACCOUNT_DISABLED_CLAIM_URI, "true"));
         setupExecutorMetadata("notifyUserAccountStatus", "true");
-        when(mockFlowUser.isAccountLocked()).thenReturn(false);
-        when(mockFlowUser.isAccountDisabled()).thenReturn(true);
 
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_RETRY);
-        Assert.assertEquals(response.getErrorMessage(),
-                "{{password.reset.user.resolver.account.disabled}}");
+        Assert.assertEquals(response.getI18nKey(), "{{account.disabled}}");
+        Assert.assertEquals(response.getErrorMessage(), "The account is disabled.");
     }
 
     @Test
     public void testAccountLocked_withNotifyAccountStatusDisabled() throws Exception {
 
-        setupUserWithClaims();
+        setupUserWithClaims(buildClaim(FrameworkConstants.ACCOUNT_LOCKED_CLAIM_URI, "true"));
         setupExecutorMetadata("notifyUserAccountStatus", "false");
-        when(mockFlowUser.isAccountLocked()).thenReturn(true);
 
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
@@ -415,9 +416,8 @@ public class UserResolveExecutorTestCase {
     @Test
     public void testAccountStatus_withNullCurrentNode() throws Exception {
 
-        setupUserWithClaims();
+        setupUserWithClaims(buildClaim(FrameworkConstants.ACCOUNT_LOCKED_CLAIM_URI, "true"));
         when(mockContext.getCurrentNode()).thenReturn(null);
-        when(mockFlowUser.isAccountLocked()).thenReturn(true);
 
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
@@ -435,14 +435,23 @@ public class UserResolveExecutorTestCase {
         when(mockExecutorDTO.getMetadata()).thenReturn(metadata);
     }
 
-    private void setupUserWithClaims() throws Exception {
+    private void setupUserWithClaims(Claim... additionalClaims) throws Exception {
 
         when(mockFlowUser.getClaim(FrameworkConstants.USERNAME_CLAIM)).thenReturn(TEST_USERNAME);
         when(mockUserStoreManager.isExistingUser(TEST_DOMAIN_QUALIFIED_USERNAME)).thenReturn(true);
-        Claim emailClaim = new Claim();
-        emailClaim.setClaimUri("http://wso2.org/claims/emailaddress");
-        emailClaim.setValue("test@example.com");
+        Claim emailClaim = buildClaim("http://wso2.org/claims/emailaddress", "test@example.com");
+        Claim[] allClaims = new Claim[1 + additionalClaims.length];
+        allClaims[0] = emailClaim;
+        System.arraycopy(additionalClaims, 0, allClaims, 1, additionalClaims.length);
         when(mockUserStoreManager.getUserClaimValues(TEST_DOMAIN_QUALIFIED_USERNAME, null))
-                .thenReturn(new Claim[]{emailClaim});
+                .thenReturn(allClaims);
+    }
+
+    private Claim buildClaim(String uri, String value) {
+
+        Claim claim = new Claim();
+        claim.setClaimUri(uri);
+        claim.setValue(value);
+        return claim;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -385,7 +385,7 @@
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>7.11.61</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.112</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.19.14, 8.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose
- This PR adds two configurable controls to UserResolveExecutor that let administrators decide whether to surface "user not found" or account locked/disabled errors — or silently succeed to prevent enumeration.

## Related Issues
- https://github.com/wso2/product-is/issues/27725

## Approach
 - **UserResolveExecutor** — Two configurable controls added, driven by executor metadata flags:

    1. **_notifyUserExistence_** — When enabled, returns a STATUS_RETRY response with an invalid.identifier error if the user is not found. When disabled, silently returns STATUS_COMPLETE (prevents user enumeration in
   recovery flows).
    2. **_notifyUserAccountStatus_** — When enabled, returns a STATUS_RETRY response with a specific error if the resolved user's account is locked (with reason-specific i18n key) or disabled. When disabled, account
  status is not surfaced to the caller.

 - **IdentifierHandlerConstants** — Added AccountLockedReason enum mapping locked-reason claim values to i18n keys and messages, plus new constants (INVALID_IDENTIFIER, ACCOUNT_DISABLED).

 - **Tests** — UserResolveExecutorTestCase extended with coverage for all combinations: user not found (notify on/off), account locked (notify on/off), account disabled (notify on/off), and the happy path.

## Related PRs
 - **(Prerequisite)** https://github.com/wso2/carbon-identity-framework/pull/8122