### PR TITLE
Handle user not found scenario when multi attribute login enabled

### DIFF
--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/pom.xml
@@ -168,6 +168,9 @@
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.flow.execution.engine.exception;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.flow.mgt.model;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.application.authentication.handler.identifier.internal,

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/pom.xml
@@ -170,7 +170,6 @@
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.flow.mgt.model;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
-
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.application.authentication.handler.identifier.internal,

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandlerConstants.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandlerConstants.java
@@ -39,8 +39,8 @@ public abstract class IdentifierHandlerConstants {
 
     public static final String ACCOUNT_DISABLED = "The account is disabled.";
     public static final String ACCOUNT_DISABLED_I18N_KEY = "{{account.disabled}}";
-    public static final String INVALID_IDENTIFIER = "The provided identifier is invalid.";
-    public static final String INVALID_IDENTIFIER_I18N_KEY = "{{invalid.identifier}}";
+    public static final String USER_NOT_FOUND = "The user does not exist.";
+    public static final String USER_NOT_FOUND_I18N_KEY = "{{user.not.found}}";
 
     private IdentifierHandlerConstants() {
     }

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
@@ -102,8 +102,15 @@ public class UserResolveExecutor implements Executor {
     @Override
     public ExecutorResponse execute(FlowExecutionContext context) {
 
+        if (isUserInputInvalid(context)) {
+            return new ExecutorResponse(STATUS_USER_INPUT_REQUIRED);
+        }
+
         String usernameClaim = resolveUsernameClaim(context);
         if (usernameClaim == null) {
+            if (isNotifyUserExistenceEnabled(context)) {
+                return buildUserNotFoundResponse();
+            }
             return new ExecutorResponse(STATUS_USER_INPUT_REQUIRED);
         }
         return resolveUser(usernameClaim, context.getTenantDomain(), context);
@@ -173,10 +180,7 @@ public class UserResolveExecutor implements Executor {
                             tenantDomain + "'.");
                 }
                 if (isNotifyUserExistenceEnabled(context)) {
-                    executorResponse.setResult(STATUS_RETRY);
-                    executorResponse.addMessage(MessageType.ERROR, IdentifierHandlerConstants.INVALID_IDENTIFIER,
-                            IdentifierHandlerConstants.INVALID_IDENTIFIER_I18N_KEY);
-                    return executorResponse;
+                    return buildUserNotFoundResponse();
                 }
                 executorResponse.setResult(STATUS_COMPLETE);
             } else {
@@ -278,6 +282,42 @@ public class UserResolveExecutor implements Executor {
             usernameClaim = (String) context.getFlowUser().getClaim(FrameworkConstants.USERNAME_CLAIM);
         }
         return usernameClaim;
+    }
+
+    /**
+     * Determines whether user input is blank and required to resolve the user. When multi-attribute login is enabled,
+     * either a user identifier or the username claim must be present; otherwise only the username claim is required.
+     *
+     * @param context Flow execution context.
+     * @return True if neither a usable identifier nor the username claim is available.
+     */
+    private boolean isUserInputInvalid(FlowExecutionContext context) {
+
+        boolean usernameInputValueExist = StringUtils.isBlank((String)
+                context.getFlowUser().getClaim(FrameworkConstants.USERNAME_CLAIM));
+
+        boolean userIdentifierValueExist = StringUtils.isBlank(context.getUserInputData().get(USER_IDENTIFIER));
+
+        if (IdentifierAuthenticatorServiceComponent.getMultiAttributeLogin().isEnabled(context.getTenantDomain())) {
+            return userIdentifierValueExist && usernameInputValueExist;
+        } else {
+            return usernameInputValueExist;
+        }
+    }
+
+    /**
+     * Builds the "user does not exist" retry response. Callers should invoke this only when user existence
+     * notification is enabled.
+     *
+     * @return A retry {@link ExecutorResponse} carrying the user-not-found message.
+     */
+    private ExecutorResponse buildUserNotFoundResponse() {
+
+        ExecutorResponse executorResponse = new ExecutorResponse();
+        executorResponse.setResult(STATUS_RETRY);
+        executorResponse.addMessage(MessageType.ERROR, IdentifierHandlerConstants.USER_NOT_FOUND,
+                IdentifierHandlerConstants.USER_NOT_FOUND_I18N_KEY);
+        return executorResponse;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
@@ -293,15 +293,15 @@ public class UserResolveExecutor implements Executor {
      */
     private boolean isUserInputInvalid(FlowExecutionContext context) {
 
-        boolean usernameInputValueExist = StringUtils.isBlank((String)
+        boolean usernameInputValueNotExist = StringUtils.isBlank((String)
                 context.getFlowUser().getClaim(FrameworkConstants.USERNAME_CLAIM));
 
-        boolean userIdentifierValueExist = StringUtils.isBlank(context.getUserInputData().get(USER_IDENTIFIER));
+        boolean userIdentifierValueNotExist = StringUtils.isBlank(context.getUserInputData().get(USER_IDENTIFIER));
 
         if (IdentifierAuthenticatorServiceComponent.getMultiAttributeLogin().isEnabled(context.getTenantDomain())) {
-            return userIdentifierValueExist && usernameInputValueExist;
+            return userIdentifierValueNotExist && usernameInputValueNotExist;
         } else {
-            return usernameInputValueExist;
+            return usernameInputValueNotExist;
         }
     }
 

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
@@ -111,7 +111,7 @@ public class UserResolveExecutor implements Executor {
             if (isNotifyUserExistenceEnabled(context)) {
                 return buildUserNotFoundResponse();
             }
-            return new ExecutorResponse(STATUS_USER_INPUT_REQUIRED);
+            return new ExecutorResponse(STATUS_COMPLETE);
         }
         return resolveUser(usernameClaim, context.getTenantDomain(), context);
     }

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
@@ -293,13 +293,13 @@ public class UserResolveExecutor implements Executor {
      */
     private boolean isUserInputInvalid(FlowExecutionContext context) {
 
-        boolean usernameInputValueNotExist = StringUtils.isBlank((String)
+        boolean isUsernameClaimMissing = StringUtils.isBlank((String)
                 context.getFlowUser().getClaim(FrameworkConstants.USERNAME_CLAIM));
         if (IdentifierAuthenticatorServiceComponent.getMultiAttributeLogin().isEnabled(context.getTenantDomain())) {
-            boolean userIdentifierValueNotExist = StringUtils.isBlank(context.getUserInputData().get(USER_IDENTIFIER));
-            return userIdentifierValueNotExist && usernameInputValueNotExist;
+            boolean isUserIdentifierMissing = StringUtils.isBlank(context.getUserInputData().get(USER_IDENTIFIER));
+            return isUserIdentifierMissing && isUsernameClaimMissing;
         } else {
-            return usernameInputValueNotExist;
+            return isUsernameClaimMissing;
         }
     }
 

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
@@ -295,8 +295,8 @@ public class UserResolveExecutor implements Executor {
 
         boolean usernameInputValueNotExist = StringUtils.isBlank((String)
                 context.getFlowUser().getClaim(FrameworkConstants.USERNAME_CLAIM));
-        boolean userIdentifierValueNotExist = StringUtils.isBlank(context.getUserInputData().get(USER_IDENTIFIER));
         if (IdentifierAuthenticatorServiceComponent.getMultiAttributeLogin().isEnabled(context.getTenantDomain())) {
+            boolean userIdentifierValueNotExist = StringUtils.isBlank(context.getUserInputData().get(USER_IDENTIFIER));
             return userIdentifierValueNotExist && usernameInputValueNotExist;
         } else {
             return usernameInputValueNotExist;

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/UserResolveExecutor.java
@@ -295,9 +295,7 @@ public class UserResolveExecutor implements Executor {
 
         boolean usernameInputValueNotExist = StringUtils.isBlank((String)
                 context.getFlowUser().getClaim(FrameworkConstants.USERNAME_CLAIM));
-
         boolean userIdentifierValueNotExist = StringUtils.isBlank(context.getUserInputData().get(USER_IDENTIFIER));
-
         if (IdentifierAuthenticatorServiceComponent.getMultiAttributeLogin().isEnabled(context.getTenantDomain())) {
             return userIdentifierValueNotExist && usernameInputValueNotExist;
         } else {

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/test/java/org/wso2/carbon/identity/application/authenticator/handler/identifier/UserResolveExecutorTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/test/java/org/wso2/carbon/identity/application/authenticator/handler/identifier/UserResolveExecutorTestCase.java
@@ -19,6 +19,7 @@ import org.wso2.carbon.identity.flow.mgt.model.MessageDTO;
 import org.wso2.carbon.identity.flow.mgt.model.MessageDTO.MessageType;
 import org.wso2.carbon.identity.flow.mgt.model.NodeConfig;
 import org.wso2.carbon.identity.multi.attribute.login.mgt.MultiAttributeLoginService;
+import org.wso2.carbon.identity.multi.attribute.login.mgt.ResolvedUserResult;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreException;
@@ -87,6 +88,7 @@ public class UserResolveExecutorTestCase {
 
     private UserResolveExecutor userResolveExecutor;
     private final Map<String, Object> userClaims = new HashMap<>();
+    private final Map<String, String> userInputData = new HashMap<>();
     private AutoCloseable closeable;
     private MockedStatic<IdentityUtil> identityUtilMock;
 
@@ -108,6 +110,7 @@ public class UserResolveExecutorTestCase {
         // Mock context setup
         when(mockContext.getFlowUser()).thenReturn(mockFlowUser);
         when(mockContext.getTenantDomain()).thenReturn(TEST_TENANT_DOMAIN);
+        when(mockContext.getUserInputData()).thenReturn(userInputData);
         when(mockFlowUser.getClaim(FrameworkConstants.USERNAME_CLAIM)).thenReturn(userClaims.get(FrameworkConstants.USERNAME_CLAIM));
 
         // Mock realm service setup
@@ -133,6 +136,7 @@ public class UserResolveExecutorTestCase {
     public void tearDown() throws Exception {
 
         userClaims.clear();
+        userInputData.clear();
         if (identityUtilMock != null) {
             identityUtilMock.close();
         }
@@ -315,7 +319,7 @@ public class UserResolveExecutorTestCase {
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_RETRY);
-        assertSingleErrorMessage(response, "The provided identifier is invalid.", "{{invalid.identifier}}");
+        assertSingleErrorMessage(response, "The user does not exist.", "{{user.not.found}}");
     }
 
     @Test
@@ -342,6 +346,53 @@ public class UserResolveExecutorTestCase {
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
         Assert.assertEquals(response.getResult(), STATUS_COMPLETE);
+    }
+
+    // Tests for resolving the user via a multi-attribute login identifier (e.g. mobile, email).
+
+    @Test
+    public void testMultiAttributeIdentifierNotFound_withNotifyUserExistenceEnabled() throws Exception {
+
+        // Multi-attribute login enabled, an identifier supplied, but no user resolves for it.
+        when(mockMultiAttributeLoginService.isEnabled(anyString())).thenReturn(true);
+        when(mockMultiAttributeLoginService.resolveUser(anyString(), anyString()))
+                .thenReturn(new ResolvedUserResult(ResolvedUserResult.UserResolvedStatus.FAIL));
+        userInputData.put(UserResolveExecutor.USER_IDENTIFIER, "0771234567");
+        when(mockFlowUser.getClaim(FrameworkConstants.USERNAME_CLAIM)).thenReturn(null);
+        setupExecutorMetadata("notifyUserExistence", "true");
+
+        ExecutorResponse response = userResolveExecutor.execute(mockContext);
+
+        Assert.assertEquals(response.getResult(), STATUS_RETRY);
+        assertSingleErrorMessage(response, "The user does not exist.", "{{user.not.found}}");
+    }
+
+    @Test
+    public void testMultiAttributeEnabledWithBlankIdentifier_returnsInputRequired() throws Exception {
+
+        // Multi-attribute login enabled but no identifier supplied yet, so input is requested.
+        when(mockMultiAttributeLoginService.isEnabled(anyString())).thenReturn(true);
+        when(mockFlowUser.getClaim(FrameworkConstants.USERNAME_CLAIM)).thenReturn(null);
+
+        ExecutorResponse response = userResolveExecutor.execute(mockContext);
+
+        Assert.assertEquals(response.getResult(), STATUS_USER_INPUT_REQUIRED);
+        verify(mockMultiAttributeLoginService, never()).resolveUser(anyString(), anyString());
+    }
+
+    @Test
+    public void testMultiAttributeIdentifierNotFound_withNotifyUserExistenceDisabled() throws Exception {
+
+        when(mockMultiAttributeLoginService.isEnabled(anyString())).thenReturn(true);
+        when(mockMultiAttributeLoginService.resolveUser(anyString(), anyString()))
+                .thenReturn(new ResolvedUserResult(ResolvedUserResult.UserResolvedStatus.FAIL));
+        userInputData.put(UserResolveExecutor.USER_IDENTIFIER, "0771234567");
+        when(mockFlowUser.getClaim(FrameworkConstants.USERNAME_CLAIM)).thenReturn(null);
+        setupExecutorMetadata("notifyUserExistence", "false");
+
+        ExecutorResponse response = userResolveExecutor.execute(mockContext);
+
+        Assert.assertEquals(response.getResult(), STATUS_USER_INPUT_REQUIRED);
     }
 
     // Tests for notifying user account status.

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/test/java/org/wso2/carbon/identity/application/authenticator/handler/identifier/UserResolveExecutorTestCase.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/test/java/org/wso2/carbon/identity/application/authenticator/handler/identifier/UserResolveExecutorTestCase.java
@@ -392,7 +392,7 @@ public class UserResolveExecutorTestCase {
 
         ExecutorResponse response = userResolveExecutor.execute(mockContext);
 
-        Assert.assertEquals(response.getResult(), STATUS_USER_INPUT_REQUIRED);
+        Assert.assertEquals(response.getResult(), STATUS_COMPLETE);
     }
 
     // Tests for notifying user account status.


### PR DESCRIPTION
## Purpose
- This pull request updates the identifier-based user resolution logic in `UseResolveExecutor` to improve error handling and support for multi-attribute login scenarios by introducing new methods for validating user input, and give retry response when the user does not exist.

## Related Issues
- https://github.com/wso2/product-is/issues/27725
- https://github.com/wso2/product-is/issues/27854

## Related PRs
 - **(Prerequisite)** https://github.com/wso2/carbon-identity-framework/pull/8122
 - https://github.com/wso2-extensions/identity-local-auth-basicauth/pull/276