### PR TITLE
Fix active session limit incorrectly bypassed for any SSO attempt

### DIFF
--- a/components/org.wso2.carbon.identity.application.authentication.handler.session/src/main/java/org/wso2/carbon/identity/application/authentication/handler/session/ActiveSessionsLimitHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.session/src/main/java/org/wso2/carbon/identity/application/authentication/handler/session/ActiveSessionsLimitHandler.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.application.authentication.handler.session;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -156,9 +155,9 @@ public class ActiveSessionsLimitHandler extends AbstractApplicationAuthenticator
                     userSessions = getUserSessions(userId, tenantDomain);
                 }
 
-                if (userSessions != null && userSessions.size() >= maxSessionCount &&
-                        !isSingleSignOnAttempt(context, userSessions)) {
-                    prepareEndpointParams(context, maxSessionCountParamValue, userSessions);
+                List<UserSession> sessionsToCheck = excludeCurrentSession(context, userSessions);
+                if (sessionsToCheck != null && sessionsToCheck.size() >= maxSessionCount) {
+                    prepareEndpointParams(context, maxSessionCountParamValue, sessionsToCheck);
                     return super.process(request, response, context);
                 } else {
                     this.publishAuthenticationStepAttempt(request, context, context.getSubject(), true);
@@ -218,10 +217,10 @@ public class ActiveSessionsLimitHandler extends AbstractApplicationAuthenticator
                 maxSessionCount = Integer.parseInt(maxSessionCountParamValue);
                 String tenantDomain = getUserTenantDomain(context);
                 userSessions = getUserSessions(userId, tenantDomain);
-                if (userSessions != null && userSessions.size() >= maxSessionCount &&
-                        !isSingleSignOnAttempt(context, userSessions)) {
-                    prepareEndpointParams(context, maxSessionCountParamValue, userSessions);
-                    throw new AuthenticationFailedException("Active session count: " + userSessions.size()
+                List<UserSession> sessionsToCheck = excludeCurrentSession(context, userSessions);
+                if (sessionsToCheck != null && sessionsToCheck.size() >= maxSessionCount) {
+                    prepareEndpointParams(context, maxSessionCountParamValue, sessionsToCheck);
+                    throw new AuthenticationFailedException("Active session count: " + sessionsToCheck.size()
                             + " exceeds the specified limit: " + maxSessionCountParamValue);
                 }
             } catch (UserSessionTerminationException e) {
@@ -495,19 +494,27 @@ public class ActiveSessionsLimitHandler extends AbstractApplicationAuthenticator
     }
 
     /**
-     * Check whether the current authentication attempt is a single sign-on attempt.
+     * Exclude the session currently being reused for this authentication attempt (e.g. an SSO
+     * request reusing an existing browser session) from the given session list. Without this
+     * exclusion, a session being legitimately reused for SSO would count against itself and
+     * always appear to meet/exceed the limit, and independently, any other concurrent session
+     * beyond the limit would go undetected as long as the current session matched itself.
      *
      * @param context      Authentication context.
-     * @param userSessions List of user sessions.
-     * @return True if the current authentication attempt is a single sign-on attempt.
+     * @param userSessions List of the user's active sessions.
+     * @return Sessions other than the one currently being used for this request, if any.
      */
-    private boolean isSingleSignOnAttempt(AuthenticationContext context, List<UserSession> userSessions) {
+    private List<UserSession> excludeCurrentSession(AuthenticationContext context, List<UserSession> userSessions) {
 
-        String sessionIdFromContext = context.getSessionIdentifier();
-        if (StringUtils.isNotBlank(sessionIdFromContext)) {
-            return userSessions.stream()
-                    .anyMatch(userSession -> sessionIdFromContext.equals(userSession.getSessionId()));
+        if (userSessions == null) {
+            return null;
         }
-        return false;
+        String currentSessionId = context.getSessionIdentifier();
+        if (StringUtils.isNotBlank(currentSessionId)) {
+            return userSessions.stream()
+                    .filter(userSession -> !currentSessionId.equals(userSession.getSessionId()))
+                    .collect(Collectors.toList());
+        }
+        return userSessions;
     }
 }


### PR DESCRIPTION
## Purpose

`ActiveSessionsLimitHandler.isSingleSignOnAttempt()` (introduced in #227) skips the active session limit check whenever the current authentication attempt's own session identifier appears anywhere in the user's fetched session list. Since the session being reused for SSO is always one of the entries in that list, the check unconditionally short-circuits on **every** SSO attempt — regardless of how many *other*, genuinely independent concurrent sessions the user has. This effectively disables the feature for any user who ever does cross-app SSO.

Example: `MaxSessionCount: 1`, user has 2 fully independent active sessions (e.g. two browsers). SSO-ing a 3rd time into an app with the limit handler configured should prompt for session termination (3 concurrent sessions > limit of 1), but it doesn't — the 3rd session matches itself in the list and the whole check is bypassed.

## Fix

Replace the boolean "is this SSO, then skip entirely" gate with a count that excludes the current session (identified via `context.getSessionIdentifier()`) before comparing against `MaxSessionCount`. This preserves the intended SSO-reuse exemption (a session doesn't count against itself) while still catching excess *other* concurrent sessions.

Related Issue - https://github.com/wso2/product-is/issues/27824

## Testing

Verified locally against a wso2is-7.3.0 pack with two SPs (App1: basic-only; App2: basic + this handler, `MaxSessionCount=1`, adaptive script):
- Regression check: solo SSO reuse with no other active sessions still shows no prompt (unchanged from #227 behavior).
- Bug repro: with 2 independent active sessions, SSO-ing a 3rd time now correctly redirects to the session-termination prompt (previously skipped it and issued the auth code directly).