### PR TITLE
[Temporary][Do not release] Add AUTHDIAG logs across identifier-first user resolution

### DIFF
--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
@@ -555,11 +555,9 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
          This is going to be removed after the multi attribute user resolving logic is moved to each authenticator.
          Hence, don't rely on this logic for new authenticators.
          */
-        boolean malEnabled = IdentifierAuthenticatorServiceComponent.getMultiAttributeLogin()
-                .isEnabled(context.getTenantDomain());
-        // AUTHDIAG (temporary) - multi attribute login is one of two paths that can bind the user id here.
-        log.info("AUTHDIAG idf-mal enabled=" + malEnabled + " tenant=" + tenantDomain);
-        if (malEnabled) {
+        if (IdentifierAuthenticatorServiceComponent.getMultiAttributeLogin().isEnabled(context.getTenantDomain())) {
+            // AUTHDIAG (temporary) - multi attribute login is one of the paths that can bind the user id here.
+            log.info("AUTHDIAG idf-mal enabled=true tenant=" + tenantDomain);
             ResolvedUserResult resolvedUserResult = IdentifierAuthenticatorServiceComponent.getMultiAttributeLogin().
                     resolveUser(tenantAwareUsername, tenantDomain);
             log.info("AUTHDIAG idf-mal-result null=" + (resolvedUserResult == null)
@@ -866,23 +864,21 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
 
             // If the userId is still not resolved and the username is not domain qualified, try to find
             // the user from secondary user stores.
-            boolean secondaryWalkRan = userId == null
-                    && StringUtils.equals(identifierFromRequest, tenantAwareUsername);
-            // AUTHDIAG (temporary) - the secondary store walk only runs when the primary missed.
-            log.info("AUTHDIAG idf-validate-walk willWalkSecondaries=" + secondaryWalkRan);
-            if (secondaryWalkRan) {
+            if (userId == null && StringUtils.equals(identifierFromRequest, tenantAwareUsername)) {
+                // AUTHDIAG (temporary) - the secondary store walk runs only when the primary missed.
+                log.info("AUTHDIAG idf-validate-walk started=true");
                 UserStoreManager secondaryUserStoreManager = userStoreManager.getSecondaryUserStoreManager();
                 while (secondaryUserStoreManager != null) {
                     String domain = secondaryUserStoreManager.getRealmConfiguration()
                             .getUserStoreProperties().get(PROPERTY_DOMAIN_NAME);
-                    boolean existsHere = userStoreManager.isExistingUser(domain + DOMAIN_SEPARATOR +
-                            tenantAwareUsername);
                     // AUTHDIAG (temporary) - each secondary store considered.
-                    log.info("AUTHDIAG idf-validate-try domain=" + domain + " exists=" + existsHere);
-                    if (existsHere) {
+                    log.info("AUTHDIAG idf-validate-try domain=" + domain);
+                    if (userStoreManager.isExistingUser(domain + DOMAIN_SEPARATOR +
+                            tenantAwareUsername)) {
                         userId = userStoreManager.getUserIDFromUserName(
                                 domain + DOMAIN_SEPARATOR + tenantAwareUsername);
                         userStoreDomain = domain;
+                        // AUTHDIAG (temporary) - the id bound from a secondary store.
                         log.info("AUTHDIAG idf-validate-secondary-set userId=" + userId
                                 + " domain=" + userStoreDomain);
                         break;

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
@@ -673,6 +673,11 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
             userStoreDomain = IdentityUtil.extractDomainFromName(username);
         }
 
+        // AUTHDIAG (temporary) - the diagnostic log below drops a null user id during JSON
+        // serialisation, so log it explicitly here. "null" means nothing bound the id at step 1.
+        log.info("AUTHDIAG idf-subject userId=" + userId + " domain=" + userStoreDomain
+                + " tenant=" + tenantDomain);
+
         AuthenticatedUser user = new AuthenticatedUser();
         user.setUserId(userId);
         user.setUserName(tenantAwareUsername);

--- a/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
+++ b/components/org.wso2.carbon.identity.application.authentication.handler.identifier/src/main/java/org/wso2/carbon/identity/application/authentication/handler/identifier/IdentifierHandler.java
@@ -555,15 +555,23 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
          This is going to be removed after the multi attribute user resolving logic is moved to each authenticator.
          Hence, don't rely on this logic for new authenticators.
          */
-        if (IdentifierAuthenticatorServiceComponent.getMultiAttributeLogin().isEnabled(context.getTenantDomain())) {
+        boolean malEnabled = IdentifierAuthenticatorServiceComponent.getMultiAttributeLogin()
+                .isEnabled(context.getTenantDomain());
+        // AUTHDIAG (temporary) - multi attribute login is one of two paths that can bind the user id here.
+        log.info("AUTHDIAG idf-mal enabled=" + malEnabled + " tenant=" + tenantDomain);
+        if (malEnabled) {
             ResolvedUserResult resolvedUserResult = IdentifierAuthenticatorServiceComponent.getMultiAttributeLogin().
                     resolveUser(tenantAwareUsername, tenantDomain);
+            log.info("AUTHDIAG idf-mal-result null=" + (resolvedUserResult == null)
+                    + " status=" + (resolvedUserResult == null ? null : resolvedUserResult.getResolvedStatus()));
             if (resolvedUserResult != null && ResolvedUserResult.UserResolvedStatus.SUCCESS.
                     equals(resolvedUserResult.getResolvedStatus())) {
                 tenantAwareUsername = resolvedUserResult.getUser().getUsername();
                 username = UserCoreUtil.addTenantDomainToEntry(tenantAwareUsername, tenantDomain);
                 userId = resolvedUserResult.getUser().getUserID();
                 userStoreDomain = resolvedUserResult.getUser().getUserStoreDomain();
+                // AUTHDIAG (temporary) - the id bound by multi attribute login.
+                log.info("AUTHDIAG idf-mal-set userId=" + userId + " domain=" + userStoreDomain);
                 // Set a property to the context to indicate that the user is resolved from this step.
                 setIsUserResolvedToContext(context);
             }
@@ -581,6 +589,15 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
           If the "ValidateUsername" adaptive parameter is set, it should be honoured regardless of the
           authenticator config.
          */
+        // AUTHDIAG (temporary) - which ValidateUsername source is in play. The adaptive script
+        // parameter takes precedence; only when it is unset does the authenticator config apply, and
+        // the two take different branches - the script parameter can reach the resident org resolver.
+        log.info("AUTHDIAG idf-validate-gate scriptParam=" + validateUsernameAdaptiveParam
+                + " authenticatorConfig=" + (getAuthenticatorConfig().getParameterMap() == null ? null
+                        : getAuthenticatorConfig().getParameterMap().get("ValidateUsername"))
+                + " callerPath=" + context.getCallerPath()
+                + " userIdSoFar=" + userId + " domainSoFar=" + userStoreDomain);
+
         if (StringUtils.isNotBlank(validateUsernameAdaptiveParam)) {
             if (Boolean.parseBoolean(validateUsernameAdaptiveParam)) {
                 boolean isUsernameValidationRequired = false;
@@ -592,6 +609,11 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
                             int tenantId = IdentityTenantUtil.getTenantId(requestTenantDomain);
                             Tenant tenant = (Tenant) IdentifierAuthenticatorServiceComponent.getRealmService()
                                     .getTenantManager().getTenant(tenantId);
+                            // AUTHDIAG (temporary) - the resident organization resolver branch.
+                            log.info("AUTHDIAG idf-residentorg-gate tenantId=" + tenantId
+                                    + " tenantNull=" + (tenant == null)
+                                    + " associatedOrgUUID="
+                                    + (tenant == null ? null : tenant.getAssociatedOrganizationUUID()));
                             if (tenant != null && StringUtils.isNotBlank(tenant.getAssociatedOrganizationUUID())) {
                                 isUsernameValidationRequired = true;
                                 org.wso2.carbon.user.core.common.User user = IdentifierAuthenticatorServiceComponent
@@ -605,6 +627,9 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
                                         tenantAwareUsername, user.getTenantDomain());
                                 userId = user.getUserID();
                                 userStoreDomain = user.getUserStoreDomain();
+                                // AUTHDIAG (temporary) - the id bound by the resident organization resolver.
+                                log.info("AUTHDIAG idf-residentorg-set userId=" + userId
+                                        + " domain=" + userStoreDomain + " tenant=" + user.getTenantDomain());
                                 // Set a property to the context to indicate that the user is resolved from this step.
                                 setIsUserResolvedToContext(context);
                             }
@@ -832,20 +857,34 @@ public class IdentifierHandler extends AbstractApplicationAuthenticator
             // or not.
             if (userId == null) {
                 userId = userStoreManager.getUserIDFromUserName(tenantAwareUsername);
+                // AUTHDIAG (temporary) - the primary store lookup. The username carries no domain here,
+                // so this only ever consults the primary store.
+                log.info("AUTHDIAG idf-validate-primary storeClass="
+                        + userStoreManager.getClass().getSimpleName()
+                        + " found=" + (userId != null) + " userId=" + userId);
             }
 
             // If the userId is still not resolved and the username is not domain qualified, try to find
             // the user from secondary user stores.
-            if (userId == null && StringUtils.equals(identifierFromRequest, tenantAwareUsername)) {
+            boolean secondaryWalkRan = userId == null
+                    && StringUtils.equals(identifierFromRequest, tenantAwareUsername);
+            // AUTHDIAG (temporary) - the secondary store walk only runs when the primary missed.
+            log.info("AUTHDIAG idf-validate-walk willWalkSecondaries=" + secondaryWalkRan);
+            if (secondaryWalkRan) {
                 UserStoreManager secondaryUserStoreManager = userStoreManager.getSecondaryUserStoreManager();
                 while (secondaryUserStoreManager != null) {
                     String domain = secondaryUserStoreManager.getRealmConfiguration()
                             .getUserStoreProperties().get(PROPERTY_DOMAIN_NAME);
-                    if (userStoreManager.isExistingUser(domain + DOMAIN_SEPARATOR +
-                            tenantAwareUsername)) {
+                    boolean existsHere = userStoreManager.isExistingUser(domain + DOMAIN_SEPARATOR +
+                            tenantAwareUsername);
+                    // AUTHDIAG (temporary) - each secondary store considered.
+                    log.info("AUTHDIAG idf-validate-try domain=" + domain + " exists=" + existsHere);
+                    if (existsHere) {
                         userId = userStoreManager.getUserIDFromUserName(
                                 domain + DOMAIN_SEPARATOR + tenantAwareUsername);
                         userStoreDomain = domain;
+                        log.info("AUTHDIAG idf-validate-secondary-set userId=" + userId
+                                + " domain=" + userStoreDomain);
                         break;
                     }
                     secondaryUserStoreManager = secondaryUserStoreManager.getSecondaryUserStoreManager();


### PR DESCRIPTION
> **This is temporary diagnostic logging. It will be reverted once the flow is identified, and must not reach production.**

## Purpose

Identify which code path first resolves `AuthenticatedUser.userId` during an identifier-first +
passkey login, and what user store domain is in effect at that moment.

Tracking issue: wso2-enterprise/asgardeo-product#36685
Related: wso2-iam-internal#7857 (groups missing from the token)

## Why it is needed

For affected logins the token carries the wrong user record — `sub` and all claims resolve to one
record while the passkey resolves against another. We have confirmed from dev diagnostic logs that
the `userId` is **null** at the end of the identifier-first step, so the ID is bound lazily somewhere
later. Which path does it, and with which domain, is the open question.

Correlation logs cannot answer this on their own: `AuthenticatedUser.getLoggableUserId()` and
`getLoggableMaskedUserId()` resolve the ID against the user store but never cache it, so a
`UM_USER_ID` query in the SQL log does not imply the ID was bound.

## Notes

- Every line is prefixed `AUTHDIAG` and marked `// AUTHDIAG (temporary)`, so the revert is a
  single grep.
- No usernames are logged in any form. User IDs are logged as-is, consistent with existing platform
  behaviour — `getLoggableMaskedUserId()` returns the user ID unmasked and masks only the username
  fallback, and `IdentifierHandler` / `FIDOAuthenticator` already log `USER_ID` raw. Caller traces
  contain class names and line numbers only.

## What is logged here

Every branch that can bind the user id at the identifier-first step.

| marker | records |
|---|---|
| `idf-mal` / `idf-mal-result` / `idf-mal-set` | multi attribute login: enabled for the tenant, resolution status, and the id bound |
| `idf-validate-gate` | which `ValidateUsername` source is in play — the adaptive script parameter, the authenticator config, or neither — plus the caller path and the id resolved so far |
| `idf-residentorg-gate` / `idf-residentorg-set` | the resident organization resolver: associated organization uuid, and the id it bound |
| `idf-validate-primary` | the primary store lookup, and the store class it ran against |
| `idf-validate-walk` / `idf-validate-try` / `idf-validate-secondary-set` | whether the secondary walk runs, each store considered, and the id bound |
| `idf-subject` | the user id and domain finally set on the subject |

## Notes

The two `ValidateUsername` sources are not equivalent. The adaptive script parameter and the
authenticator config take different branches, and only the script parameter can reach
`resolveUserFromResidentOrganization`. `idf-validate-gate` records both so the branch is unambiguous.

`idf-subject` prints a null user id explicitly. The existing diagnostic log at the same point already
logs `USER_ID`, but a null value is dropped during Gson serialisation, so its absence there is
ambiguous — that cost us a round trip on this investigation.
